### PR TITLE
Fixes duplicate_cmd issue in Replace state for CIsco ASA acls resource

### DIFF
--- a/plugins/module_utils/network/asa/config/acls/acls.py
+++ b/plugins/module_utils/network/asa/config/acls/acls.py
@@ -30,7 +30,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from ansible_collections.cisco.asa.plugins.module_utils.network.asa.utils.utils import (
     new_dict_to_set,
 )
-import q
+
 
 class Acls(ConfigBase):
     """

--- a/plugins/module_utils/network/asa/config/acls/acls.py
+++ b/plugins/module_utils/network/asa/config/acls/acls.py
@@ -202,9 +202,16 @@ class Acls(ConfigBase):
                                                     ) == temp_acls_have.get(
                                                         "name"
                                                     ):
-                                                        clear_cmd = self._clear_config(temp_ace_have, temp_acls_have)
-                                                        commands = self.add_config_cmd(clear_cmd, commands)
-                                        commands = self.add_config_cmd(set_cmd, commands)
+                                                        clear_cmd = self._clear_config(
+                                                            temp_ace_have,
+                                                            temp_acls_have,
+                                                        )
+                                                        commands = self.add_config_cmd(
+                                                            clear_cmd, commands
+                                                        )
+                                        commands = self.add_config_cmd(
+                                            set_cmd, commands
+                                        )
                                         check = True
                                 if check:
                                     break
@@ -222,8 +229,7 @@ class Acls(ConfigBase):
             commands = [each for each in commands if "no" in each][::-1] + [
                 each for each in commands if "no" not in each
             ]
-        q(commands)
-        #commands=[]
+
         return commands
 
     def _state_overridden(self, want, have):
@@ -285,8 +291,12 @@ class Acls(ConfigBase):
                                                             temp_ace_have,
                                                             temp_acls_have,
                                                         )
-                                                        commands = self.add_config_cmd(clear_cmd, commands)
-                                            commands = self.add_config_cmd(set_cmd, commands)
+                                                        commands = self.add_config_cmd(
+                                                            clear_cmd, commands
+                                                        )
+                                            commands = self.add_config_cmd(
+                                                set_cmd, commands
+                                            )
                                         check = True
                                         del config_want.get("acls")[0].get(
                                             "aces"
@@ -409,8 +419,12 @@ class Acls(ConfigBase):
                                     ) and ace_want.get("line") == ace_have.get(
                                         "line"
                                     ):
-                                        clear_cmd = self._clear_config(ace_have, acls_have)
-                                        commands = self.add_config_cmd(clear_cmd, commands)
+                                        clear_cmd = self._clear_config(
+                                            ace_have, acls_have
+                                        )
+                                        commands = self.add_config_cmd(
+                                            clear_cmd, commands
+                                        )
         else:
             for config_have in have:
                 for acls_have in config_have.get("acls"):

--- a/tests/integration/targets/asa_acls/tests/cli/replaced.yaml
+++ b/tests/integration/targets/asa_acls/tests/cli/replaced.yaml
@@ -52,7 +52,7 @@
 
     - assert:
         that:
-          - result.commands|length == 2
+          - result.commands|length == 5
           - result.changed == true
           - result.commands|symmetric_difference(replaced.commands) == []
 

--- a/tests/integration/targets/asa_acls/tests/cli/replaced.yaml
+++ b/tests/integration/targets/asa_acls/tests/cli/replaced.yaml
@@ -14,6 +14,23 @@
       cisco.asa.asa_acls: &id001
         config:
           - acls:
+            - name: test_access
+              acl_type: extended
+              aces:
+                - grant: deny
+                  line: 1
+                  protocol: tcp
+                  protocol_options:
+                    tcp: true
+                  source:
+                    address: 192.0.3.0
+                    netmask: 255.255.255.0
+                  destination:
+                    address: 192.0.4.0
+                    netmask: 255.255.255.0
+                    port_protocol:
+                      eq: www
+                  log: default
             - name: test_global_access
               acl_type: extended
               aces:

--- a/tests/integration/targets/asa_acls/vars/main.yaml
+++ b/tests/integration/targets/asa_acls/vars/main.yaml
@@ -18,6 +18,9 @@ merged:
 replaced:
   commands:
     - no access-list test_global_access line 1 extended deny tcp any any eq www log errors
+    - no access-list test_access line 2 extended deny 198.51.100.0 255.255.255.0 198.51.110.0 255.255.255.0 log errors
+    - no access-list test_access line 1 extended deny 192.0.2.0 255.255.255.0 192.0.3.0 255.255.255.0 eq www log default
+    - access-list test_access line 1 extended deny tcp 192.0.3.0 255.255.255.0 192.0.4.0 255.255.255.0 eq www log default
     - access-list test_global_access line 1 extended deny tcp 192.0.4.0 255.255.255.0 eq telnet 192.0.5.0 255.255.255.0 eq www
 overridden:
   commands:

--- a/tests/integration/targets/asa_acls/vars/main.yaml
+++ b/tests/integration/targets/asa_acls/vars/main.yaml
@@ -17,11 +17,11 @@ merged:
     - access-list test_R1_traffic line 1 extended deny tcp 2001:db8:0:3::/64 eq www 2001:fc8:0:4::/64 eq telnet inactive
 replaced:
   commands:
-    - no access-list test_global_access line 1 extended deny tcp any any eq www log errors
-    - no access-list test_access line 2 extended deny 198.51.100.0 255.255.255.0 198.51.110.0 255.255.255.0 log errors
-    - no access-list test_access line 1 extended deny 192.0.2.0 255.255.255.0 192.0.3.0 255.255.255.0 eq www log default
-    - access-list test_access line 1 extended deny tcp 192.0.3.0 255.255.255.0 192.0.4.0 255.255.255.0 eq www log default
-    - access-list test_global_access line 1 extended deny tcp 192.0.4.0 255.255.255.0 eq telnet 192.0.5.0 255.255.255.0 eq www
+      - no access-list test_global_access line 1 extended deny tcp any any eq www log errors
+      - no access-list test_access line 2 extended deny igrp 198.51.100.0 255.255.255.0 198.51.110.0 255.255.255.0 log errors
+      - no access-list test_access line 1 extended deny tcp 192.0.2.0 255.255.255.0 192.0.3.0 255.255.255.0 eq www log default
+      - access-list test_access line 1 extended deny tcp 192.0.3.0 255.255.255.0 192.0.4.0 255.255.255.0 eq www log default
+      - access-list test_global_access line 1 extended deny tcp 192.0.4.0 255.255.255.0 eq telnet 192.0.5.0 255.255.255.0 eq www
 overridden:
   commands:
     - no access-list test_R1_traffic line 1 extended deny tcp 2001:db8:0:3::/64 eq www 2001:fc8:0:4::/64 eq telnet inactive


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes duplicate_cmd issue in Replace state for CIsco ASA acls resource, PR fixes #18 .
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_acls
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
