### PR TITLE
Fix parse description for broken idempotency on ASA v. 7

### DIFF
--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -179,7 +179,7 @@ class Parser:
         return list_return
 
     def parse_description(self):
-        match = re.search(r'description(:)?\s(.*)', self.config, re.M)
+        match = re.search(r"description(:)?\s(.*)", self.config, re.M)
         if match:
             description = match.group(2)
 

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -179,7 +179,7 @@ class Parser:
         return list_return
 
     def parse_description(self):
-        match = re.search(r"(description\s)(.*)", self.config, re.M)
+        match = re.search(r'description(:)?\s(.*)', self.config, re.M)
         if match:
             description = match.group(2)
 


### PR DESCRIPTION
On ASA Version 7, the object group description include columns (i.e. "description: "). This break idempotency.

#### SUMMARY

Update description regex to include optional columns

### ISSUE TYPE

    Bugfix Pull Request

#### COMPONENT NAME

asa_og

#### ADDITIONAL INFORMATION

```
Cisco Adaptive Security Appliance Software Version 7.2(4)

object-group network test
 description: this is a test description
```
