### PR TITLE
Fixes integers added within a task

### DIFF
--- a/plugins/module_utils/network/asa/config/acls/acls.py
+++ b/plugins/module_utils/network/asa/config/acls/acls.py
@@ -204,7 +204,10 @@ class Acls(ConfigBase):
                                             "name"
                                         ) == acls_have.get("name"):
                                             ace_want = remove_empties(ace_want)
-                                            set_cmd, check = self.common_condition_check(
+                                            (
+                                                set_cmd,
+                                                check,
+                                            ) = self.common_condition_check(
                                                 ace_want,
                                                 ace_have,
                                                 acls_want,
@@ -420,7 +423,10 @@ class Acls(ConfigBase):
                                             ace_want = dict_merge(
                                                 ace_have, ace_want
                                             )
-                                            cmd, check = self.common_condition_check(
+                                            (
+                                                cmd,
+                                                check,
+                                            ) = self.common_condition_check(
                                                 ace_want,
                                                 ace_have,
                                                 acls_want,

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -290,9 +290,7 @@ def map_config_to_obj(module):
     have_host_ip = Parser(sh_run_group_type, protocol).parse_host()
     obj_dict["have_host_ip"] = have_host_ip
 
-    have_group_object = Parser(
-        sh_run_group_type, protocol
-    ).parse_group_object()
+    have_group_object = Parser(sh_run_group_type, protocol).parse_group_object()
     obj_dict["have_group_object"] = have_group_object
 
     have_ip_mask = Parser(sh_run_group_type, protocol).parse_address()
@@ -371,84 +369,50 @@ def replace(want_dict, have):
                 if sorted(host) != sorted(have_host_ip):
                     for i in host:
                         if i not in have_host_ip:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             add_lines.append("network-object host %s" % i)
                     for i in have_host_ip:
                         if i not in host:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             remove_lines.append("no network-object host %s" % i)
 
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group network {0}".format(name)
-                        )
+                        commands.append("object-group network {0}".format(name))
                     add_lines.append("description {0}".format(description))
 
             if group_object:
                 if sorted(group_object) != sorted(have_group_object):
                     for i in group_object:
                         if i not in have_group_object:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             add_lines.append("group-object %s" % i)
                     for i in have_group_object:
                         if i not in group_object:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             remove_lines.append("no group-object %s" % i)
             if address:
                 if sorted(address) != sorted(have_ip_mask):
                     for i in address:
                         if i not in have_ip_mask:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             add_lines.append("network-object %s" % i)
                     for i in have_ip_mask:
                         if i not in address:
-                            if (
-                                "object-group network {0}".format(name)
-                                not in commands
-                            ):
-                                commands.append(
-                                    "object-group network {0}".format(name)
-                                )
+                            if "object-group network {0}".format(name) not in commands:
+                                commands.append("object-group network {0}".format(name))
                             remove_lines.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
 
         if have_group_type is None and have_protocol != protocol:
-            commands.append(
-                "object-group service {0} {1}".format(name, protocol)
-            )
+            commands.append("object-group service {0} {1}".format(name, protocol))
 
             if port_range:
                 for i in port_range:
@@ -466,9 +430,7 @@ def replace(want_dict, have):
                     for i in port_range:
                         if i not in have_port_range:
                             if (
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                                 not in commands
                             ):
                                 commands.append(
@@ -480,9 +442,7 @@ def replace(want_dict, have):
                     for i in have_port_range:
                         if i not in port_range:
                             if (
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                                 not in commands
                             ):
                                 commands.append(
@@ -496,9 +456,7 @@ def replace(want_dict, have):
                     for i in port_eq:
                         if i not in have_port_eq:
                             if (
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                                 not in commands
                             ):
                                 commands.append(
@@ -510,9 +468,7 @@ def replace(want_dict, have):
                     for i in have_port_eq:
                         if i not in port_eq:
                             if (
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                                 not in commands
                             ):
                                 commands.append(
@@ -528,9 +484,7 @@ def replace(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                         )
                     commands.append("description {0}".format(description))
 
@@ -550,30 +504,18 @@ def replace(want_dict, have):
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group service {0}".format(name)
-                        )
+                        commands.append("object-group service {0}".format(name))
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i not in have_service_cfg:
-                        if (
-                            "object-group service {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group service {0}".format(name)
-                            )
+                        if "object-group service {0}".format(name) not in commands:
+                            commands.append("object-group service {0}".format(name))
                         add_lines.append("service %s" % i)
                 for i in have_service_cfg:
                     if i not in service_cfg:
-                        if (
-                            "object-group service {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group service {0}".format(name)
-                            )
+                        if "object-group service {0}".format(name) not in commands:
+                            commands.append("object-group service {0}".format(name))
                         remove_lines.append("no service %s" % i)
 
     set_add_lines = set(add_lines)
@@ -633,50 +575,31 @@ def present(want_dict, have):
             if host:
                 for i in host:
                     if i not in have_host_ip:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("network-object host %s" % i)
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group network {0}".format(name)
-                        )
+                        commands.append("object-group network {0}".format(name))
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i not in have_group_object:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("group-object %s" % i)
             if address:
                 for i in address:
                     if i not in have_ip_mask:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("network-object %s" % i)
 
     elif "port-object" in group_type:
 
         if have_group_type is None and have_protocol != protocol:
-            commands.append(
-                "object-group service {0} {1}".format(name, protocol)
-            )
+            commands.append("object-group service {0} {1}".format(name, protocol))
 
             if port_range:
                 for i in port_range:
@@ -693,30 +616,22 @@ def present(want_dict, have):
                 for i in port_range:
                     if i not in have_port_range:
                         if (
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                             )
                         commands.append("port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i not in have_port_eq:
                         if (
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                             )
                         commands.append("port-object eq %s" % i)
             if description:
@@ -726,9 +641,7 @@ def present(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                         )
                     commands.append("description {0}".format(description))
 
@@ -749,20 +662,13 @@ def present(want_dict, have):
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group service {0}".format(name)
-                        )
+                        commands.append("object-group service {0}".format(name))
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i not in have_service_cfg:
-                        if (
-                            "object-group service {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group service {0}".format(name)
-                            )
+                        if "object-group service {0}".format(name) not in commands:
+                            commands.append("object-group service {0}".format(name))
                         commands.append("service %s" % i)
 
     return commands
@@ -803,42 +709,25 @@ def absent(want_dict, have):
             if host:
                 for i in host:
                     if i in have_host_ip:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("no network-object host %s" % i)
             if description:
                 if description == have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group network {0}".format(name)
-                        )
+                        commands.append("object-group network {0}".format(name))
                     commands.append("no description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i in have_group_object:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("no group-object %s" % i)
             if address:
                 for i in address:
                     if i in have_ip_mask:
-                        if (
-                            "object-group network {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group network {0}".format(name)
-                            )
+                        if "object-group network {0}".format(name) not in commands:
+                            commands.append("object-group network {0}".format(name))
                         commands.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
@@ -852,30 +741,22 @@ def absent(want_dict, have):
                 for i in port_range:
                     if i in have_port_range:
                         if (
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                             )
                         commands.append("no port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i in have_port_eq:
                         if (
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(
-                                    name, protocol
-                                )
+                                "object-group service {0} {1}".format(name, protocol)
                             )
                         commands.append("no port-object eq %s" % i)
             if description:
@@ -885,9 +766,7 @@ def absent(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            )
+                            "object-group service {0} {1}".format(name, protocol)
                         )
                     commands.append("no description {0}".format(description))
 
@@ -900,20 +779,13 @@ def absent(want_dict, have):
             if description:
                 if description == have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append(
-                            "object-group service {0}".format(name)
-                        )
+                        commands.append("object-group service {0}".format(name))
                     commands.append("no description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i in have_service_cfg:
-                        if (
-                            "object-group service {0}".format(name)
-                            not in commands
-                        ):
-                            commands.append(
-                                "object-group service {0}".format(name)
-                            )
+                        if "object-group service {0}".format(name) not in commands:
+                            commands.append("object-group service {0}".format(name))
                         commands.append("no service %s" % i)
 
     return commands
@@ -973,8 +845,7 @@ def main():
     argument_spec = dict(
         name=dict(required=True),
         group_type=dict(
-            choices=["network-object", "service-object", "port-object"],
-            required=True,
+            choices=["network-object", "service-object", "port-object"], required=True,
         ),
         protocol=dict(choices=["udp", "tcp", "tcp-udp"]),
         host_ip=dict(type="list"),
@@ -984,9 +855,7 @@ def main():
         port_range=dict(type="list"),
         port_eq=dict(type="list"),
         service_cfg=dict(type="list"),
-        state=dict(
-            choices=["present", "absent", "replace"], default="present"
-        ),
+        state=dict(choices=["present", "absent", "replace"], default="present"),
     )
 
     required_if = [
@@ -995,9 +864,7 @@ def main():
     ]
 
     module = AnsibleModule(
-        argument_spec=argument_spec,
-        required_if=required_if,
-        supports_check_mode=True,
+        argument_spec=argument_spec, required_if=required_if, supports_check_mode=True,
     )
 
     result = {"changed": False}

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -290,7 +290,9 @@ def map_config_to_obj(module):
     have_host_ip = Parser(sh_run_group_type, protocol).parse_host()
     obj_dict["have_host_ip"] = have_host_ip
 
-    have_group_object = Parser(sh_run_group_type, protocol).parse_group_object()
+    have_group_object = Parser(
+        sh_run_group_type, protocol
+    ).parse_group_object()
     obj_dict["have_group_object"] = have_group_object
 
     have_ip_mask = Parser(sh_run_group_type, protocol).parse_address()
@@ -369,50 +371,86 @@ def replace(want_dict, have):
                 if sorted(host) != sorted(have_host_ip):
                     for i in host:
                         if i not in have_host_ip:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
                             add_lines.append("network-object host %s" % i)
                     for i in have_host_ip:
                         if i not in host:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
-                            remove_lines.append("no network-object host %s" % i)
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
+                            remove_lines.append(
+                                "no network-object host %s" % i
+                            )
 
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append("object-group network {0}".format(name))
+                        commands.append(
+                            "object-group network {0}".format(name)
+                        )
                     add_lines.append("description {0}".format(description))
 
             if group_object:
                 if sorted(group_object) != sorted(have_group_object):
                     for i in group_object:
                         if i not in have_group_object:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
                             add_lines.append("group-object %s" % i)
                     for i in have_group_object:
                         if i not in group_object:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
                             remove_lines.append("no group-object %s" % i)
             if address:
                 if sorted(address) != sorted(have_ip_mask):
                     for i in address:
                         if i not in have_ip_mask:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
                             add_lines.append("network-object %s" % i)
                     for i in have_ip_mask:
                         if i not in address:
-                            if "object-group network {0}".format(name) not in commands:
-                                commands.append("object-group network {0}".format(name))
+                            if (
+                                "object-group network {0}".format(name)
+                                not in commands
+                            ):
+                                commands.append(
+                                    "object-group network {0}".format(name)
+                                )
                             remove_lines.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
 
         if have_group_type is None and have_protocol != protocol:
-            commands.append("object-group service {0} {1}".format(name, protocol))
+            commands.append(
+                "object-group service {0} {1}".format(name, protocol)
+            )
 
             if port_range:
                 for i in port_range:
@@ -430,7 +468,9 @@ def replace(want_dict, have):
                     for i in port_range:
                         if i not in have_port_range:
                             if (
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                                 not in commands
                             ):
                                 commands.append(
@@ -442,7 +482,9 @@ def replace(want_dict, have):
                     for i in have_port_range:
                         if i not in port_range:
                             if (
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                                 not in commands
                             ):
                                 commands.append(
@@ -456,7 +498,9 @@ def replace(want_dict, have):
                     for i in port_eq:
                         if i not in have_port_eq:
                             if (
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                                 not in commands
                             ):
                                 commands.append(
@@ -468,7 +512,9 @@ def replace(want_dict, have):
                     for i in have_port_eq:
                         if i not in port_eq:
                             if (
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                                 not in commands
                             ):
                                 commands.append(
@@ -484,7 +530,9 @@ def replace(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                         )
                     commands.append("description {0}".format(description))
 
@@ -504,18 +552,30 @@ def replace(want_dict, have):
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append("object-group service {0}".format(name))
+                        commands.append(
+                            "object-group service {0}".format(name)
+                        )
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i not in have_service_cfg:
-                        if "object-group service {0}".format(name) not in commands:
-                            commands.append("object-group service {0}".format(name))
+                        if (
+                            "object-group service {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group service {0}".format(name)
+                            )
                         add_lines.append("service %s" % i)
                 for i in have_service_cfg:
                     if i not in service_cfg:
-                        if "object-group service {0}".format(name) not in commands:
-                            commands.append("object-group service {0}".format(name))
+                        if (
+                            "object-group service {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group service {0}".format(name)
+                            )
                         remove_lines.append("no service %s" % i)
 
     set_add_lines = set(add_lines)
@@ -575,31 +635,50 @@ def present(want_dict, have):
             if host:
                 for i in host:
                     if i not in have_host_ip:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("network-object host %s" % i)
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append("object-group network {0}".format(name))
+                        commands.append(
+                            "object-group network {0}".format(name)
+                        )
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i not in have_group_object:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("group-object %s" % i)
             if address:
                 for i in address:
                     if i not in have_ip_mask:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("network-object %s" % i)
 
     elif "port-object" in group_type:
 
         if have_group_type is None and have_protocol != protocol:
-            commands.append("object-group service {0} {1}".format(name, protocol))
+            commands.append(
+                "object-group service {0} {1}".format(name, protocol)
+            )
 
             if port_range:
                 for i in port_range:
@@ -616,22 +695,30 @@ def present(want_dict, have):
                 for i in port_range:
                     if i not in have_port_range:
                         if (
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                             )
                         commands.append("port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i not in have_port_eq:
                         if (
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                             )
                         commands.append("port-object eq %s" % i)
             if description:
@@ -641,7 +728,9 @@ def present(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                         )
                     commands.append("description {0}".format(description))
 
@@ -662,13 +751,20 @@ def present(want_dict, have):
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append("object-group service {0}".format(name))
+                        commands.append(
+                            "object-group service {0}".format(name)
+                        )
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i not in have_service_cfg:
-                        if "object-group service {0}".format(name) not in commands:
-                            commands.append("object-group service {0}".format(name))
+                        if (
+                            "object-group service {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group service {0}".format(name)
+                            )
                         commands.append("service %s" % i)
 
     return commands
@@ -709,25 +805,42 @@ def absent(want_dict, have):
             if host:
                 for i in host:
                     if i in have_host_ip:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("no network-object host %s" % i)
             if description:
                 if description == have_description:
                     if "object-group network {0}".format(name) not in commands:
-                        commands.append("object-group network {0}".format(name))
+                        commands.append(
+                            "object-group network {0}".format(name)
+                        )
                     commands.append("no description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i in have_group_object:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("no group-object %s" % i)
             if address:
                 for i in address:
                     if i in have_ip_mask:
-                        if "object-group network {0}".format(name) not in commands:
-                            commands.append("object-group network {0}".format(name))
+                        if (
+                            "object-group network {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group network {0}".format(name)
+                            )
                         commands.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
@@ -741,22 +854,30 @@ def absent(want_dict, have):
                 for i in port_range:
                     if i in have_port_range:
                         if (
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                             )
                         commands.append("no port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i in have_port_eq:
                         if (
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                             not in commands
                         ):
                             commands.append(
-                                "object-group service {0} {1}".format(name, protocol)
+                                "object-group service {0} {1}".format(
+                                    name, protocol
+                                )
                             )
                         commands.append("no port-object eq %s" % i)
             if description:
@@ -766,7 +887,9 @@ def absent(want_dict, have):
                         not in commands
                     ):
                         commands.append(
-                            "object-group service {0} {1}".format(name, protocol)
+                            "object-group service {0} {1}".format(
+                                name, protocol
+                            )
                         )
                     commands.append("no description {0}".format(description))
 
@@ -779,13 +902,20 @@ def absent(want_dict, have):
             if description:
                 if description == have_description:
                     if "object-group service {0}".format(name) not in commands:
-                        commands.append("object-group service {0}".format(name))
+                        commands.append(
+                            "object-group service {0}".format(name)
+                        )
                     commands.append("no description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
                     if i in have_service_cfg:
-                        if "object-group service {0}".format(name) not in commands:
-                            commands.append("object-group service {0}".format(name))
+                        if (
+                            "object-group service {0}".format(name)
+                            not in commands
+                        ):
+                            commands.append(
+                                "object-group service {0}".format(name)
+                            )
                         commands.append("no service %s" % i)
 
     return commands
@@ -845,7 +975,8 @@ def main():
     argument_spec = dict(
         name=dict(required=True),
         group_type=dict(
-            choices=["network-object", "service-object", "port-object"], required=True,
+            choices=["network-object", "service-object", "port-object"],
+            required=True,
         ),
         protocol=dict(choices=["udp", "tcp", "tcp-udp"]),
         host_ip=dict(type="list"),
@@ -855,7 +986,9 @@ def main():
         port_range=dict(type="list"),
         port_eq=dict(type="list"),
         service_cfg=dict(type="list"),
-        state=dict(choices=["present", "absent", "replace"], default="present"),
+        state=dict(
+            choices=["present", "absent", "replace"], default="present"
+        ),
     )
 
     required_if = [
@@ -864,7 +997,9 @@ def main():
     ]
 
     module = AnsibleModule(
-        argument_spec=argument_spec, required_if=required_if, supports_check_mode=True,
+        argument_spec=argument_spec,
+        required_if=required_if,
+        supports_check_mode=True,
     )
 
     result = {"changed": False}

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -353,17 +353,17 @@ def replace(want_dict, have):
 
             if host:
                 for i in host:
-                    commands.append("network-object host " + i)
+                    commands.append("network-object host %s" % i)
             if description:
                 if have_description is None:
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i not in have_group_object:
-                        commands.append("group-object " + i)
+                        commands.append("group-object %s" % i)
             if address:
                 for i in address:
-                    commands.append("network-object " + i)
+                    commands.append("network-object %s" % i)
 
         elif "network" in have_group_type:
 
@@ -378,7 +378,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("network-object host " + i)
+                            add_lines.append("network-object host %s" % i)
                     for i in have_host_ip:
                         if i not in host:
                             if (
@@ -388,7 +388,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            remove_lines.append("no network-object host " + i)
+                            remove_lines.append("no network-object host %s" % i)
 
             if description:
                 if description != have_description:
@@ -409,7 +409,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("group-object " + i)
+                            add_lines.append("group-object %s" % i)
                     for i in have_group_object:
                         if i not in group_object:
                             if (
@@ -419,7 +419,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            remove_lines.append("no group-object " + i)
+                            remove_lines.append("no group-object %s" % i)
             if address:
                 if sorted(address) != sorted(have_ip_mask):
                     for i in address:
@@ -431,7 +431,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("network-object " + i)
+                            add_lines.append("network-object %s" % i)
                     for i in have_ip_mask:
                         if i not in address:
                             if (
@@ -441,7 +441,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            remove_lines.append("no network-object " + i)
+                            remove_lines.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
 
@@ -452,10 +452,10 @@ def replace(want_dict, have):
 
             if port_range:
                 for i in port_range:
-                    commands.append("port-object range " + i)
+                    commands.append("port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
-                    commands.append("port-object eq " + i)
+                    commands.append("port-object eq %s" % i)
             if description:
                 commands.append("description {0}".format(description))
 
@@ -476,7 +476,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            add_lines.append("port-object range " + i)
+                            add_lines.append("port-object range %s" % i)
                     for i in have_port_range:
                         if i not in port_range:
                             if (
@@ -490,7 +490,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            remove_lines.append("no port-object range " + i)
+                            remove_lines.append("no port-object range %s" % i)
             if port_eq:
                 if sorted(port_eq) != sorted(have_port_eq):
                     for i in port_eq:
@@ -506,7 +506,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            add_lines.append("port-object eq " + i)
+                            add_lines.append("port-object eq %s" % i)
                     for i in have_port_eq:
                         if i not in port_eq:
                             if (
@@ -520,7 +520,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            remove_lines.append("no port-object eq " + i)
+                            remove_lines.append("no port-object eq %s" % i)
             if description:
                 if description != have_description:
                     if (
@@ -544,7 +544,7 @@ def replace(want_dict, have):
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
-                    commands.append("service-object " + i)
+                    commands.append("service-object %s" % i)
 
         elif "service" in have_group_type:
             if description:
@@ -564,7 +564,7 @@ def replace(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        add_lines.append("service " + i)
+                        add_lines.append("service %s" % i)
                 for i in have_service_cfg:
                     if i not in service_cfg:
                         if (
@@ -574,7 +574,7 @@ def replace(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        remove_lines.append("no service " + i)
+                        remove_lines.append("no service %s" % i)
 
     set_add_lines = set(add_lines)
     set_remove_lines = set(remove_lines)
@@ -617,16 +617,16 @@ def present(want_dict, have):
 
             if host:
                 for i in host:
-                    commands.append("network-object host " + i)
+                    commands.append("network-object host %s" % i)
             if description:
                 if have_description is None:
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
-                    commands.append("group-object " + i)
+                    commands.append("group-object %s" % i)
             if address:
                 for i in address:
-                    commands.append("network-object " + i)
+                    commands.append("network-object %s" % i)
 
         elif "network" in have_group_type:
 
@@ -640,7 +640,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("network-object host " + i)
+                        commands.append("network-object host %s" % i)
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
@@ -658,7 +658,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("group-object " + i)
+                        commands.append("group-object %s" % i)
             if address:
                 for i in address:
                     if i not in have_ip_mask:
@@ -669,7 +669,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("network-object " + i)
+                        commands.append("network-object %s" % i)
 
     elif "port-object" in group_type:
 
@@ -680,10 +680,10 @@ def present(want_dict, have):
 
             if port_range:
                 for i in port_range:
-                    commands.append("port-object range " + i)
+                    commands.append("port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
-                    commands.append("port-object eq " + i)
+                    commands.append("port-object eq %s" % i)
             if description:
                 commands.append("description {0}".format(description))
 
@@ -703,7 +703,7 @@ def present(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("port-object range " + i)
+                        commands.append("port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i not in have_port_eq:
@@ -718,7 +718,7 @@ def present(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("port-object eq " + i)
+                        commands.append("port-object eq %s" % i)
             if description:
                 if description != have_description:
                     if (
@@ -742,7 +742,7 @@ def present(want_dict, have):
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
-                    commands.append("service-object " + i)
+                    commands.append("service-object %s" % i)
 
         elif "service" in have_group_type:
 
@@ -763,7 +763,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        commands.append("service " + i)
+                        commands.append("service %s" % i)
 
     return commands
 
@@ -810,7 +810,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no network-object host " + i)
+                        commands.append("no network-object host %s" % i)
             if description:
                 if description == have_description:
                     if "object-group network {0}".format(name) not in commands:
@@ -828,7 +828,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no group-object " + i)
+                        commands.append("no group-object %s" % i)
             if address:
                 for i in address:
                     if i in have_ip_mask:
@@ -839,7 +839,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no network-object " + i)
+                        commands.append("no network-object %s" % i)
 
     elif "port-object" in group_type:
 
@@ -862,7 +862,7 @@ def absent(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("no port-object range " + i)
+                        commands.append("no port-object range %s" % i)
             if port_eq:
                 for i in port_eq:
                     if i in have_port_eq:
@@ -877,7 +877,7 @@ def absent(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("no port-object eq " + i)
+                        commands.append("no port-object eq %s" % i)
             if description:
                 if description == have_description:
                     if (
@@ -914,7 +914,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        commands.append("no service " + i)
+                        commands.append("no service %s" % i)
 
     return commands
 

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -353,17 +353,17 @@ def replace(want_dict, have):
 
             if host:
                 for i in host:
-                    commands.append("network-object host %s" % i)
+                    commands.append("network-object host " + str(i))
             if description:
                 if have_description is None:
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
                     if i not in have_group_object:
-                        commands.append("group-object %s" % i)
+                        commands.append("group-object " + str(i))
             if address:
                 for i in address:
-                    commands.append("network-object %s" % i)
+                    commands.append("network-object " + str(i))
 
         elif "network" in have_group_type:
 
@@ -378,7 +378,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("network-object host %s" % i)
+                            add_lines.append("network-object host " + str(i))
                     for i in have_host_ip:
                         if i not in host:
                             if (
@@ -389,7 +389,7 @@ def replace(want_dict, have):
                                     "object-group network {0}".format(name)
                                 )
                             remove_lines.append(
-                                "no network-object host %s" % i
+                                "no network-object host " + str(i)
                             )
 
             if description:
@@ -411,7 +411,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("group-object %s" % i)
+                            add_lines.append("group-object " + str(i))
                     for i in have_group_object:
                         if i not in group_object:
                             if (
@@ -421,7 +421,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            remove_lines.append("no group-object %s" % i)
+                            remove_lines.append("no group-object " + str(i))
             if address:
                 if sorted(address) != sorted(have_ip_mask):
                     for i in address:
@@ -433,7 +433,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            add_lines.append("network-object %s" % i)
+                            add_lines.append("network-object " + str(i))
                     for i in have_ip_mask:
                         if i not in address:
                             if (
@@ -443,7 +443,7 @@ def replace(want_dict, have):
                                 commands.append(
                                     "object-group network {0}".format(name)
                                 )
-                            remove_lines.append("no network-object %s" % i)
+                            remove_lines.append("no network-object " + str(i))
 
     elif "port-object" in group_type:
 
@@ -454,10 +454,10 @@ def replace(want_dict, have):
 
             if port_range:
                 for i in port_range:
-                    commands.append("port-object range %s" % i)
+                    commands.append("port-object range " + str(i))
             if port_eq:
                 for i in port_eq:
-                    commands.append("port-object eq %s" % i)
+                    commands.append("port-object eq " + str(i))
             if description:
                 commands.append("description {0}".format(description))
 
@@ -478,7 +478,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            add_lines.append("port-object range %s" % i)
+                            add_lines.append("port-object range " + str(i))
                     for i in have_port_range:
                         if i not in port_range:
                             if (
@@ -492,7 +492,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            remove_lines.append("no port-object range %s" % i)
+                            remove_lines.append("no port-object range " + str(i))
             if port_eq:
                 if sorted(port_eq) != sorted(have_port_eq):
                     for i in port_eq:
@@ -508,7 +508,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            add_lines.append("port-object eq %s" % i)
+                            add_lines.append("port-object eq " + str(i))
                     for i in have_port_eq:
                         if i not in port_eq:
                             if (
@@ -522,7 +522,7 @@ def replace(want_dict, have):
                                         name, protocol
                                     )
                                 )
-                            remove_lines.append("no port-object eq %s" % i)
+                            remove_lines.append("no port-object eq " + str(i))
             if description:
                 if description != have_description:
                     if (
@@ -546,7 +546,7 @@ def replace(want_dict, have):
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
-                    commands.append("service-object %s" % i)
+                    commands.append("service-object " + str(i))
 
         elif "service" in have_group_type:
             if description:
@@ -566,7 +566,7 @@ def replace(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        add_lines.append("service %s" % i)
+                        add_lines.append("service " + str(i))
                 for i in have_service_cfg:
                     if i not in service_cfg:
                         if (
@@ -576,7 +576,7 @@ def replace(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        remove_lines.append("no service %s" % i)
+                        remove_lines.append("no service " + str(i))
 
     set_add_lines = set(add_lines)
     set_remove_lines = set(remove_lines)
@@ -619,16 +619,16 @@ def present(want_dict, have):
 
             if host:
                 for i in host:
-                    commands.append("network-object host %s" % i)
+                    commands.append("network-object host " + str(i))
             if description:
                 if have_description is None:
                     commands.append("description {0}".format(description))
             if group_object:
                 for i in group_object:
-                    commands.append("group-object %s" % i)
+                    commands.append("group-object " + str(i))
             if address:
                 for i in address:
-                    commands.append("network-object %s" % i)
+                    commands.append("network-object " + str(i))
 
         elif "network" in have_group_type:
 
@@ -642,7 +642,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("network-object host %s" % i)
+                        commands.append("network-object host " + str(i))
             if description:
                 if description != have_description:
                     if "object-group network {0}".format(name) not in commands:
@@ -660,7 +660,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("group-object %s" % i)
+                        commands.append("group-object " + str(i))
             if address:
                 for i in address:
                     if i not in have_ip_mask:
@@ -671,7 +671,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("network-object %s" % i)
+                        commands.append("network-object " + str(i))
 
     elif "port-object" in group_type:
 
@@ -682,10 +682,10 @@ def present(want_dict, have):
 
             if port_range:
                 for i in port_range:
-                    commands.append("port-object range %s" % i)
+                    commands.append("port-object range " + str(i))
             if port_eq:
                 for i in port_eq:
-                    commands.append("port-object eq %s" % i)
+                    commands.append("port-object eq " + str(i))
             if description:
                 commands.append("description {0}".format(description))
 
@@ -705,7 +705,7 @@ def present(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("port-object range %s" % i)
+                        commands.append("port-object range " + str(i))
             if port_eq:
                 for i in port_eq:
                     if i not in have_port_eq:
@@ -720,7 +720,7 @@ def present(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("port-object eq %s" % i)
+                        commands.append("port-object eq " + str(i))
             if description:
                 if description != have_description:
                     if (
@@ -744,7 +744,7 @@ def present(want_dict, have):
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
-                    commands.append("service-object %s" % i)
+                    commands.append("service-object " + str(i))
 
         elif "service" in have_group_type:
 
@@ -765,7 +765,7 @@ def present(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        commands.append("service %s" % i)
+                        commands.append("service " + str(i))
 
     return commands
 
@@ -812,7 +812,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no network-object host %s" % i)
+                        commands.append("no network-object host " + str(i))
             if description:
                 if description == have_description:
                     if "object-group network {0}".format(name) not in commands:
@@ -830,7 +830,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no group-object %s" % i)
+                        commands.append("no group-object " + str(i))
             if address:
                 for i in address:
                     if i in have_ip_mask:
@@ -841,7 +841,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group network {0}".format(name)
                             )
-                        commands.append("no network-object %s" % i)
+                        commands.append("no network-object " + str(i))
 
     elif "port-object" in group_type:
 
@@ -864,7 +864,7 @@ def absent(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("no port-object range %s" % i)
+                        commands.append("no port-object range " + str(i))
             if port_eq:
                 for i in port_eq:
                     if i in have_port_eq:
@@ -879,7 +879,7 @@ def absent(want_dict, have):
                                     name, protocol
                                 )
                             )
-                        commands.append("no port-object eq %s" % i)
+                        commands.append("no port-object eq " + str(i))
             if description:
                 if description == have_description:
                     if (
@@ -916,7 +916,7 @@ def absent(want_dict, have):
                             commands.append(
                                 "object-group service {0}".format(name)
                             )
-                        commands.append("no service %s" % i)
+                        commands.append("no service " + str(i))
 
     return commands
 

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -232,6 +232,7 @@
         port_eq:
           - www
           - '1024'
+          - 1212
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
         port_range:
           - 1024 10024

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -231,7 +231,7 @@
         name: ansible_test_3
         port_eq:
           - www
-          - 1024
+          - "1024"
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
         port_range:
           - 1024 10024

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -232,6 +232,7 @@
         port_eq:
           - www
           - "1024"
+          - 1024
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
         port_range:
           - 1024 10024

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -231,7 +231,6 @@
         name: ansible_test_3
         port_eq:
           - www
-          - "1024"
           - 1024
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
         port_range:

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -231,8 +231,7 @@
         name: ansible_test_3
         port_eq:
           - www
-          - '1024'
-          - 1212
+          - 1024
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
         port_range:
           - 1024 10024


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes everywhere that has `"somestring " + i` over to`"somestring %s" % i`. This will allow for integers to be used within task definitions. Choose % formatting as this is the preferred method speed wise until f-strings are adopted within Ansible.

Is that something we could just move to here now with using a Collection?

Fixes #28 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_og

##### ADDITIONAL INFORMATION
All updates made based on where there was a `" + i`.
