### PR TITLE
Handle src & backup properly when module alias is used

### DIFF
--- a/changelogs/fragments/fix_config_module_src_backup.yaml
+++ b/changelogs/fragments/fix_config_module_src_backup.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Make `src`, `backup` and `backup_options` in asa_config work when module alias is used (https://github.com/ansible-collections/cisco.asa/pull/61).

--- a/plugins/action/asa.py
+++ b/plugins/action/asa.py
@@ -43,7 +43,9 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         module_name = self._task.action.split(".")[-1]
-        self._config_module = True if module_name == "asa_config" else False
+        self._config_module = (
+            True if module_name in ["asa_config", "config"] else False
+        )
 
         if self._play_context.connection == "local":
             provider = load_provider(asa_provider_spec, self._task.args)

--- a/tests/integration/targets/asa_config/tasks/main.yaml
+++ b/tests/integration/targets/asa_config/tasks/main.yaml
@@ -2,3 +2,6 @@
 - include: cli.yaml
   tags:
     - cli
+
+- include: redirection.yaml
+  when: ansible_version.full is version('2.10.0', '>=')

--- a/tests/integration/targets/asa_config/tasks/redirection.yaml
+++ b/tests/integration/targets/asa_config/tasks/redirection.yaml
@@ -1,0 +1,18 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: '{{ role_path }}/tests/redirection'
+    patterns: '{{ testcase }}.yaml'
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: Run test case (connection=ansible.netcommon.network_cli)
+  include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_config/tests/redirection/shortname.yaml
+++ b/tests/integration/targets/asa_config/tests/redirection/shortname.yaml
@@ -1,0 +1,36 @@
+---
+- debug: msg="START redirection/shortname.yaml on connection={{ ansible_connection }}"
+
+- name: Use src with module alias
+  register: result
+  cisco.asa.config:
+    src: basic/config.j2
+
+- assert:
+    that:
+      # make sure that the template content was read and not the path
+      - result.failed == false
+
+- name: use module alias to take configuration backup
+  register: result
+  cisco.asa.config:
+    backup: true
+    backup_options:
+      filename: backup_with_alias.cfg
+      dir_path: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}'
+
+- assert:
+    that:
+      - result.changed == true
+
+- name: check if the backup file exist
+  find:
+    paths: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup_with_alias.cfg'
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - backup_file.files is defined
+
+- debug: msg="END redirection/shortname.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/595

##### SUMMARY
- Module name will not always be prefixed with {{ network_os }}_.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
action/asa.py
asa_config.py
