### PR TITLE
Fix TypeError: argument of type 'NoneType' is not iterable in service-group

### DIFF
--- a/changelogs/fragments/71_fix_NoneType_in_service_group.yaml
+++ b/changelogs/fragments/71_fix_NoneType_in_service_group.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix TypeError argument of type 'NoneType' is not iterable in service-group when service-group does not exists.

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -570,7 +570,20 @@ def replace(want_dict, have):
                     commands.append("description {0}".format(description))
             if service_cfg:
                 for i in service_cfg:
-                    if i not in have_service_cfg:
+
+                    if have_service_cfg is None:
+                        if (
+                            "object-group service {0}".format(name) 
+                            not in commands:
+                        ):
+                            commands.append(
+                              "object-group service {0}".format(name)
+                            )
+                        commands.append(
+                          'service ' + i
+                        )                        
+                    
+                    elif i not in have_service_cfg:
                         if (
                             "object-group service {0}".format(name)
                             not in commands

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -561,7 +561,7 @@ def replace(want_dict, have):
                     commands.append("service-object " + i)
 
         elif "service" in have_group_type:
-            
+
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
@@ -569,22 +569,22 @@ def replace(want_dict, have):
                             "object-group service {0}".format(name)
                         )
                     commands.append("description {0}".format(description))
-            
+
             if service_cfg:
-                
+
                 for i in service_cfg:
                     if have_service_cfg is None:
                         if (
-                            "object-group service {0}".format(name) 
+                            "object-group service {0}".format(name)
                             not in commands
-                            ):
+                        ):
 
                             commands.append(
-                              "object-group service {0}".format(name)
+                                "object-group service {0}".format(name)
                             )
 
-                        commands.append('service ' + i)                        
-                    
+                        commands.append('service ' + i)          
+
                     elif i not in have_service_cfg:
                         if (
                             "object-group service {0}".format(name)

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -583,7 +583,7 @@ def replace(want_dict, have):
                                 "object-group service {0}".format(name)
                             )
 
-                        commands.append('service ' + i)    
+                        commands.append('service ' + i)
 
                     elif i not in have_service_cfg:
                         if (

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -583,7 +583,7 @@ def replace(want_dict, have):
                                 "object-group service {0}".format(name)
                             )
 
-                        commands.append('service ' + i)
+                        commands.append("service " + i)
 
                     elif i not in have_service_cfg:
                         if (

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -561,6 +561,7 @@ def replace(want_dict, have):
                     commands.append("service-object " + i)
 
         elif "service" in have_group_type:
+            
             if description:
                 if description != have_description:
                     if "object-group service {0}".format(name) not in commands:
@@ -568,20 +569,21 @@ def replace(want_dict, have):
                             "object-group service {0}".format(name)
                         )
                     commands.append("description {0}".format(description))
+            
             if service_cfg:
+                
                 for i in service_cfg:
-
                     if have_service_cfg is None:
                         if (
                             "object-group service {0}".format(name) 
-                            not in commands:
-                        ):
+                            not in commands
+                            ):
+
                             commands.append(
                               "object-group service {0}".format(name)
                             )
-                        commands.append(
-                          'service ' + i
-                        )                        
+
+                        commands.append('service ' + i)                        
                     
                     elif i not in have_service_cfg:
                         if (
@@ -592,6 +594,7 @@ def replace(want_dict, have):
                                 "object-group service {0}".format(name)
                             )
                         add_lines.append("service " + i)
+
                 for i in have_service_cfg:
                     if i not in service_cfg:
                         if (

--- a/plugins/modules/asa_og.py
+++ b/plugins/modules/asa_og.py
@@ -583,7 +583,7 @@ def replace(want_dict, have):
                                 "object-group service {0}".format(name)
                             )
 
-                        commands.append('service ' + i)          
+                        commands.append('service ' + i)    
 
                     elif i not in have_service_cfg:
                         if (


### PR DESCRIPTION
##### SUMMARY
`TypeError: argument of type 'NoneType' is not iterable in service-group` when service-object not existing in ASA V. 9.6(3)17 <context>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
asa_og.py

##### ADDITIONAL INFORMATION
```
{
    "module_stdout": "",
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.network.asa.asa_og', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 801, in <module>\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 788, in main\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 735, in map_obj_to_commands\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 602, in present\nTypeError: argument of type 'NoneType' is not iterable\n",
    "exception": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/var/lib/awx/.ansible/tmp/ansible-local-7917vsjauk24/ansible-tmp-1599135052.5277274-179017891288941/AnsiballZ_asa_og.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.network.asa.asa_og', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 801, in <module>\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 788, in main\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 735, in map_obj_to_commands\n  File \"/tmp/ansible_asa_og_payload_qfhj60mq/ansible_asa_og_payload.zip/ansible/modules/network/asa/asa_og.py\", line 602, in present\nTypeError: argument of type 'NoneType' is not iterable\n",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1,
    "_ansible_no_log": false,
    "changed": false,
    "item": {
        "name": "ftp_svc",
        "description": "GNS-39102 - Infosec Security Tools",
        "service_cfg": [
            "tcp destination eq ftp",
            "tcp destination eq ftp-data"
        ]
    },
    "ansible_loop_var": "item",
    "_ansible_item_label": {
        "name": "ftp_svc",
        "description": "GNS-39102 - Infosec Security Tools",
        "service_cfg": [
            "tcp destination eq ftp",
            "tcp destination eq ftp-data"
        ]
    }
}
```
