### PR TITLE
Add basic support for FTD mode

### DIFF
--- a/plugins/terminal/asa.py
+++ b/plugins/terminal/asa.py
@@ -33,6 +33,7 @@ class TerminalModule(TerminalBase):
     terminal_stdout_re = [
         re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
+        re.compile(br"[\r\n]?(?:>|#) ?$")
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
ASA in FTD mode has a different console cli.
After login first connects leaves you at "> ", which is not recognized by the regEx and a command timeout is raised since it never detects the prompt in the output.
By simply adding this string basic cli is recognized

https://www.cisco.com/c/en/us/td/docs/security/firepower/command_ref/b_Command_Reference_for_Firepower_Threat_Defense/using_the_FTD_CLI.html

