### PR TITLE
Add support for single_user_mode

### DIFF
--- a/changelogs/fragments/single_user_mode.yaml
+++ b/changelogs/fragments/single_user_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add support for configuration caching (single_user_mode).
+  - Re-use device_info dictionary in cliconf.

--- a/plugins/terminal/asa.py
+++ b/plugins/terminal/asa.py
@@ -41,6 +41,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"^Command authorization failed\r?$", re.MULTILINE),
     ]
 
+    terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")
+
     def on_open_shell(self):
         if self._get_prompt().strip().endswith(b"#"):
             self.disable_pager()

--- a/tests/integration/targets/asa_smoke/defaults/main.yaml
+++ b/tests/integration/targets/asa_smoke/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: '[^_].*'
+test_items: []

--- a/tests/integration/targets/asa_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/asa_smoke/tasks/cli.yaml
@@ -1,0 +1,22 @@
+---
+- name: Collect all cli test cases
+  find:
+    paths: '{{ role_path }}/tests'
+    patterns: '{{ testcase }}.yaml'
+    use_regex: true
+  register: test_cases
+  delegate_to: localhost
+
+- name: Set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+  delegate_to: localhost
+
+- name: Run test case (connection=network_cli)
+  include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: network_cli
+    ansible_network_single_user_mode: True
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_smoke/tasks/main.yaml
+++ b/tests/integration/targets/asa_smoke/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- include: cli.yaml
+  tags:
+    - cli

--- a/tests/integration/targets/asa_smoke/tests/caching.yaml
+++ b/tests/integration/targets/asa_smoke/tests/caching.yaml
@@ -1,0 +1,101 @@
+---
+- block:
+  - debug: msg="START connection={{ ansible_connection }} caching.yaml"
+
+  - set_fact:
+      merged:
+      - object-group security test_og_security
+      - description test_security
+      - security-group name test_1
+      - security-group name test_2
+      - security-group tag 10
+      - security-group tag 20
+      - object-group network test_og_network
+      - description test_og_network
+      - network-object 192.0.2.0 255.255.255.0
+      - network-object 198.51.100.0 255.255.255.0
+      - network-object host 192.0.2.1
+      - network-object host 192.0.2.2
+      - object-group network test_network_og
+      - description test_network_og
+      - network-object host 192.0.3.1
+      - network-object host 192.0.3.2
+      - network-object 2001:db8:3::/64
+      - object-group user test_og_user
+      - description test_user
+      - user LOCAL\new_user_1
+      - user LOCAL\new_user_2
+
+  - name: Remove OG Config
+    cisco.asa.asa_ogs:
+      state: deleted
+    ignore_errors: True
+
+  - name: Merge the provided configuration with the exisiting running configuration
+    cisco.asa.asa_ogs: &id001
+      config:
+        - object_type: network
+          object_groups:
+            - name: test_og_network
+              description: test_og_network
+              network_object:
+                host:
+                  - 192.0.2.1
+                  - 192.0.2.2
+                address:
+                  - 192.0.2.0 255.255.255.0
+                  - 198.51.100.0 255.255.255.0
+            - name: test_network_og
+              description: test_network_og
+              network_object:
+                host:
+                  - 192.0.3.1
+                  - 192.0.3.2
+                ipv6_address:
+                  - 2001:db8:3::/64
+        - object_type: security
+          object_groups:
+            - name: test_og_security
+              description: test_security
+              security_group:
+                sec_name:
+                  - test_1
+                  - test_2
+                tag:
+                  - 10
+                  - 20
+        - object_type: user
+          object_groups:
+            - name: test_og_user
+              description: test_user
+              user_object:
+                user:
+                  - name: new_user_1
+                    domain: LOCAL
+                  - name: new_user_2
+                    domain: LOCAL
+      state: merged
+    register: result
+
+  - assert:
+      that:
+        - result.commands|length == 21
+        - result.changed == true
+        - result.commands|symmetric_difference(merged) == []
+
+  - name: Merge the provided configuration with the exisiting running configuration
+        (IDEMPOTENT)
+    register: result
+    cisco.asa.asa_ogs: *id001
+
+  - assert:
+      that:
+        - result.commands|length == 0
+        - result.changed == false
+
+  always:
+    - name: Remove OG Config
+      cisco.asa.asa_ogs:
+        state: deleted
+      ignore_errors: True
+  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
Depends-On: https://github.com/ansible-collections/cisco.asa/pull/90

##### SUMMARY
- Targets ansible-collections/ansible.netcommon#73
- Add support for ansible_single_user_mode option added in network_cli.
- Re-use device_info dictionary for every session.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/asa.py
terminal/asa.py