### PR TITLE
To fix asa_ogs protocol object to except protocol number as well as input

### DIFF
--- a/changelogs/fragments/116_ogs_protocol_object_fix.yaml
+++ b/changelogs/fragments/116_ogs_protocol_object_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes asa_ogs protocol object to except protocol number as input (https://github.com/ansible-collections/cisco.asa/issues/116).

--- a/plugins/module_utils/network/asa/argspec/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/argspec/ogs/ogs.py
@@ -101,32 +101,7 @@ class OGsArgs(object):
                         "protocol_object": {
                             "type": "dict",
                             "options": {
-                                "protocol": {
-                                    "type": "list",
-                                    "elements": "str",
-                                    "choices": [
-                                        "ah",
-                                        "eigrp",
-                                        "esp",
-                                        "gre",
-                                        "icmp",
-                                        "icmp6",
-                                        "igmp",
-                                        "igrp",
-                                        "ip",
-                                        "ipinip",
-                                        "ipsec",
-                                        "nos",
-                                        "ospf",
-                                        "pcp",
-                                        "pim",
-                                        "pptp",
-                                        "sctp",
-                                        "snp",
-                                        "tcp",
-                                        "udp",
-                                    ],
-                                }
+                                "protocol": {"type": "list", "elements": "str"}
                             },
                         },
                         "security_group": {

--- a/plugins/module_utils/network/asa/config/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/config/ogs/ogs.py
@@ -494,7 +494,7 @@ class OGs(ResourceModule):
                         obj_cmd_added = True
 
     def _add_group_object_cmd(self, want, have):
-        if have:
+        if have and have.get("group_object"):
             want["group_object"] = list(
                 set(want.get("group_object")) - set(have.get("group_object"))
             )
@@ -503,7 +503,11 @@ class OGs(ResourceModule):
             )
         for each in want["group_object"]:
             self.compare(["group_object"], {"group_object": each}, dict())
-        if (self.state == "replaced" or self.state == "overridden") and have:
+        if (
+            (self.state == "replaced" or self.state == "overridden")
+            and have
+            and have.get("group_object")
+        ):
             for each in have["group_object"]:
                 self.compare(["group_object"], dict(), {"group_object": each})
 

--- a/plugins/modules/asa_ogs.py
+++ b/plugins/modules/asa_ogs.py
@@ -107,11 +107,11 @@ options:
             type: dict
             suboptions:
               protocol:
-                description: Defines the protocols in the group.
+                description:
+                  - Defines the protocols in the group.
+                  - User can either specify protocols directly/protocol numbers(0-255)
                 type: list
                 elements: str
-                choices: [ah, eigrp, esp, gre, icmp, icmp6, igmp, igrp, ip, ipinip,
-                  ipsec, nos, ospf, pcp, pim, pptp, sctp, snp, tcp, udp]
           security_group:
             description: Configure a security-group
             type: dict

--- a/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
+++ b/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
@@ -17,3 +17,5 @@ object-group user test_user_obj
   user LOCAL\test1
 object-group user group_user_obj
   group-object test_user_obj
+object-group protocol test_protocol
+ protocol-object 16

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -125,6 +125,15 @@ class TestAsaOGsModule(TestAsaModule):
                         ],
                         object_type="user",
                     ),
+                    dict(
+                        object_groups=[
+                            dict(
+                                name="test_protocol",
+                                protocol_object=dict(protocol=["tcp", "16"]),
+                            )
+                        ],
+                        object_type="protocol",
+                    ),
                 ],
                 state="merged",
             )
@@ -142,6 +151,8 @@ class TestAsaOGsModule(TestAsaModule):
             "network-object object NEW_TEST",
             "object-group user test_user_obj",
             "user-group domain\\\\test_merge",
+            "object-group protocol test_protocol",
+            "protocol tcp",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
@@ -199,6 +210,15 @@ class TestAsaOGsModule(TestAsaModule):
                             ),
                         ],
                         object_type="user",
+                    ),
+                    dict(
+                        object_groups=[
+                            dict(
+                                name="test_protocol",
+                                protocol_object=dict(protocol=["16"]),
+                            )
+                        ],
+                        object_type="protocol",
                     ),
                 ],
                 state="merged",
@@ -293,6 +313,15 @@ class TestAsaOGsModule(TestAsaModule):
                         ],
                         object_type="user",
                     ),
+                    dict(
+                        object_groups=[
+                            dict(
+                                name="test_protocol",
+                                protocol_object=dict(protocol=["16"]),
+                            )
+                        ],
+                        object_type="protocol",
+                    ),
                 ],
                 state="replaced",
             )
@@ -324,6 +353,7 @@ class TestAsaOGsModule(TestAsaModule):
         commands = [
             "no object-group service test_og_service",
             "no object-group network group_network_obj",
+            "no object-group protocol test_protocol",
             "object-group network test_og_network",
             "description test_og_network_override",
             "no network-object 192.0.2.0 255.255.255.0",
@@ -391,6 +421,15 @@ class TestAsaOGsModule(TestAsaModule):
                         ],
                         object_type="user",
                     ),
+                    dict(
+                        object_groups=[
+                            dict(
+                                name="test_protocol",
+                                protocol_object=dict(protocol=["16"]),
+                            )
+                        ],
+                        object_type="protocol",
+                    ),
                 ],
                 state="overridden",
             )
@@ -420,6 +459,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no object-group network group_network_obj",
             "no object-group network test_og_network",
             "no object-group network ANSIBLE_TEST",
+            "no object-group protocol test_protocol",
             "no object-group service test_og_service",
             "no object-group user group_user_obj",
             "no object-group user test_user_obj",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix asa_ogs protocol object to except protocol number as well as input. Fixes #116 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_ogs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
