### PR TITLE
Correct Two Differences In The Sanity Test for 'pylint'

### DIFF
--- a/changelogs/fragments/129_sanity_test_cleanup_for_pylint.yml
+++ b/changelogs/fragments/129_sanity_test_cleanup_for_pylint.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+trivial:
   - Corrects two errors in the sanity test for 'pylint' under Python 3.8

--- a/changelogs/fragments/129_sanity_test_cleanup_for_pylint.yml
+++ b/changelogs/fragments/129_sanity_test_cleanup_for_pylint.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Corrects two errors in the sanity test for 'pylint' under Python 3.8

--- a/plugins/cliconf/asa.py
+++ b/plugins/cliconf/asa.py
@@ -98,7 +98,7 @@ class Cliconf(CliconfBase):
         return self._device_info
 
     @enable_mode
-    def get_config(self, source="running", format="text", flags=None):
+    def get_config(self, source="running", flags=None, format="text"):
         if source not in ("running", "startup"):
             return self.invalid_params(
                 "fetching configuration from %s is not supported" % source

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -46,12 +46,12 @@ class DictDataLoader(DataLoader):
 
     # TODO: the real _get_file_contents returns a bytestring, so we actually convert the
     #       unicode/text it's created with to utf-8
-    def _get_file_contents(self, path):
-        path = to_text(path)
+    def _get_file_contents(self, file_name):
+        path = to_text(file_name)
         if path in self._file_mapping:
-            return (to_bytes(self._file_mapping[path]), False)
+            return to_bytes(self._file_mapping[file_name]), False
         else:
-            raise AnsibleParserError("file not found: %s" % path)
+            raise AnsibleParserError("file not found: %s" % file_name)
 
     def path_exists(self, path):
         path = to_text(path)

--- a/tests/unit/modules/network/asa/test_asa_facts.py
+++ b/tests/unit/modules/network/asa/test_asa_facts.py
@@ -69,9 +69,7 @@ class TestAsaFactsModule(TestAsaModule):
             output = list()
 
             for command in commands:
-                filename = (
-                    str(command).split(" | ", maxsplit=1)[0].replace(" ", "_")
-                )
+                filename = str(command).split(" | ", 1)[0].replace(" ", "_")
                 output.append(load_fixture("asa_facts_%s" % filename))
             return output
 

--- a/tests/unit/modules/network/asa/test_asa_facts.py
+++ b/tests/unit/modules/network/asa/test_asa_facts.py
@@ -69,7 +69,9 @@ class TestAsaFactsModule(TestAsaModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(" | ")[0].replace(" ", "_")
+                filename = (
+                    str(command).split(" | ", maxsplit=1)[0].replace(" ", "_")
+                )
                 output.append(load_fixture("asa_facts_%s" % filename))
             return output
 


### PR DESCRIPTION
##### SUMMARY
Cleans up 2 of the 4 failures in the 'pylint' test under Python 3.8 that is currently failing in CI.

Validated locally with `podman` via the `quay.io/ansible/network-ee-sanity-tests:latest` like Zuul is running.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
quay.io/ansible/network-ee-sanity-tests:latest

##### ADDITIONAL INFORMATION
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

```bash
Running sanity test 'pylint' with Python 3.8
ERROR: Found 4 pylint issue(s) which need to be resolved:
ERROR: plugins/cliconf/asa.py:101:4: arguments-renamed: Parameter 'flags' has been renamed to 'format' in overridden 'Cliconf.get_config' method
ERROR: plugins/cliconf/asa.py:101:4: arguments-renamed: Parameter 'format' has been renamed to 'flags' in overridden 'Cliconf.get_config' method
```

The 'Cliconf.get_config' method is an abstract method so we might as well mirror the keyword argument ordering.

```bash
$ grep -r '.get_config('
plugins/cliconf/asa.py:    def get_config(self, source="running", flags=None, format="text"):
plugins/module_utils/network/asa/asa.py:def get_config(module, flags=None):
plugins/module_utils/network/asa/providers/module.py:        current_config = self.connection.get_config(flags=config_filter)
plugins/modules/asa_acl.py:        contents = get_config(module)
plugins/modules/asa_config.py:            contents = get_config(module)
plugins/modules/asa_config.py:        result["__backup__"] = get_config(module)
plugins/modules/asa_og.py:    sh_run_group_name = get_config(
plugins/modules/asa_og.py:    sh_run_group_type = get_config(
```

These calls to 'get_config' are easily traceable to the 'get_config' defined in 'plugins/module_utils/network/asa/asa.py':

- plugins/module_utils/network/asa/providers/module.py
- plugins/modules/asa_acl.py
- plugins/modules/asa_og.py

```python
from ansible_collections.cisco.asa.plugins.module_utils.network.asa.asa import (
    get_config,
    load_config,
)
```

The 'get_config' call in 'plugins/module_utils/network/asa/providers/module.py' is the only one I'm not certain on. I could see how via the Connection object it would come back the new 'Cliconf' based approach. Even if that's true though it specifies it's argument by keyword and would be unaffected by an ordering change.
