### PR TITLE
To fix asa_ogs for parsing network object with ipv6 host address as expected

### DIFF
--- a/changelogs/fragments/128_fix_asa_ogs_networkobject_host_with_ipv6.yaml
+++ b/changelogs/fragments/128_fix_asa_ogs_networkobject_host_with_ipv6.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix asa_ogs for parsing network object with ipv6 host address as expected (https://github.com/ansible-collections/cisco.asa/issues/128).

--- a/plugins/module_utils/network/asa/rm_templates/ogs.py
+++ b/plugins/module_utils/network/asa/rm_templates/ogs.py
@@ -192,7 +192,7 @@ class OGsTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""\s+network-object*
                     \s*(?P<host_obj>host)*
-                    \s*(?P<host_address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
+                    \s*(?P<host_address>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(\S+::\d+|\S+::/\d+))
                     *$""",
                 re.VERBOSE,
             ),

--- a/plugins/module_utils/network/asa/rm_templates/ogs.py
+++ b/plugins/module_utils/network/asa/rm_templates/ogs.py
@@ -188,6 +188,24 @@ class OGsTemplate(NetworkTemplate):
             },
         },
         {
+            "name": "network_object.ipv6_address",
+            "getval": re.compile(
+                r"""\s+network-object*
+                    \s*(?P<ipv6>\S+::/\d+)
+                    *$""",
+                re.VERBOSE,
+            ),
+            "setval": _tmplt_network_object_ipv6,
+            "compval": "network_object.ipv6_address",
+            "result": {
+                "ogs": {
+                    "{{ obj_type }}": {
+                        "{{ obj_name }}": {"ipv6_address": ["{{ ipv6 }}"]}
+                    }
+                }
+            },
+        },
+        {
             "name": "network_object.host",
             "getval": re.compile(
                 r"""\s+network-object*
@@ -202,24 +220,6 @@ class OGsTemplate(NetworkTemplate):
                 "ogs": {
                     "{{ obj_type }}": {
                         "{{ obj_name }}": {"host": ["{{ host_address }}"]}
-                    }
-                }
-            },
-        },
-        {
-            "name": "network_object.ipv6_address",
-            "getval": re.compile(
-                r"""\s+network-object*
-                    \s*(?P<ipv6>\S+::/\d+)
-                    *$""",
-                re.VERBOSE,
-            ),
-            "setval": _tmplt_network_object_ipv6,
-            "compval": "network_object.ipv6_address",
-            "result": {
-                "ogs": {
-                    "{{ obj_type }}": {
-                        "{{ obj_name }}": {"ipv6_address": ["{{ ipv6 }}"]}
                     }
                 }
             },

--- a/plugins/module_utils/network/asa/rm_templates/ogs.py
+++ b/plugins/module_utils/network/asa/rm_templates/ogs.py
@@ -192,7 +192,7 @@ class OGsTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""\s+network-object*
                     \s*(?P<host_obj>host)*
-                    \s*(?P<host_address>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(\S+::\d+|\S+::/\d+))
+                    \s*(?P<host_address>\S+)
                     *$""",
                 re.VERBOSE,
             ),

--- a/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
+++ b/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
@@ -4,6 +4,7 @@ object-group network ANSIBLE_TEST
 object-group network test_og_network
   description test_og_network
   network-object host 192.0.2.1
+  network-object host 2001:db8::1
   network-object 192.0.2.0 255.255.255.0
 object-group network group_network_obj
   group-object ANSIBLE_TEST

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -170,7 +170,7 @@ class TestAsaOGsModule(TestAsaModule):
                                 description="test_og_network",
                                 name="test_og_network",
                                 network_object=dict(
-                                    host=["192.0.2.1"],
+                                    host=["192.0.2.1", "2001:db8::1"],
                                     address=["192.0.2.0 255.255.255.0"],
                                 ),
                             ),
@@ -254,6 +254,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no network-object 192.0.2.0 255.255.255.0",
             "network-object 192.0.3.0 255.255.255.0",
             "no network-object host 192.0.2.1",
+            "no network-object host 2001:db8::1",
             "network-object host 192.0.3.1",
         ]
         self.assertEqual(result["commands"], commands)
@@ -272,7 +273,7 @@ class TestAsaOGsModule(TestAsaModule):
                                 description="test_og_network",
                                 name="test_og_network",
                                 network_object=dict(
-                                    host=["192.0.2.1"],
+                                    host=["192.0.2.1", "2001:db8::1"],
                                     address=["192.0.2.0 255.255.255.0"],
                                 ),
                             ),
@@ -359,6 +360,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no network-object 192.0.2.0 255.255.255.0",
             "network-object 192.0.3.0 255.255.255.0",
             "no network-object host 192.0.2.1",
+            "no network-object host 2001:db8::1",
             "network-object host 192.0.3.1",
             "no object-group network ANSIBLE_TEST",
             "no object-group user group_user_obj",
@@ -380,7 +382,7 @@ class TestAsaOGsModule(TestAsaModule):
                                 description="test_og_network",
                                 name="test_og_network",
                                 network_object=dict(
-                                    host=["192.0.2.1"],
+                                    host=["192.0.2.1", "2001:db8::1"],
                                     address=["192.0.2.0 255.255.255.0"],
                                 ),
                             ),
@@ -476,7 +478,7 @@ class TestAsaOGsModule(TestAsaModule):
                                 description="test_og_network",
                                 name="test_og_network",
                                 network_object=dict(
-                                    host=["192.0.2.1"],
+                                    host=["192.0.2.1", "2001:db8::1"],
                                     address=["192.0.2.0 255.255.255.0"],
                                 ),
                             )
@@ -503,6 +505,7 @@ class TestAsaOGsModule(TestAsaModule):
             "description test_og_network",
             "network-object 192.0.2.0 255.255.255.0",
             "network-object host 192.0.2.1",
+            "network-object host 2001:db8::1",
             "object-group service test_og_service",
             "service-object ipinip",
             "service-object tcp-udp",

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -257,7 +257,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no network-object host 2001:db8::1",
             "network-object host 192.0.3.1",
         ]
-        self.assertEqual(result["commands"], commands)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
 
     def test_asa_ogs_replaced_idempotent(self):
         set_module_args(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix asa_ogs for parsing network object with ipv6 host address as expected. Fixes #128 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_ogs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
