### PR TITLE
132 - Fix paremeter description in docs

### DIFF
--- a/changelogs/fragments/132_fix_parameter_documentation.yml
+++ b/changelogs/fragments/132_fix_parameter_documentation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes description for "passwords" parameter in documentation (https://github.com/ansible-collections/cisco.asa/issues/132).

--- a/plugins/doc_fragments/asa.py
+++ b/plugins/doc_fragments/asa.py
@@ -31,8 +31,8 @@ class ModuleDocFragment(object):
     type: str
   passwords:
     description:
-    - Specifies which context to target if you are running in the ASA in multiple
-      context mode. Defaults to the current context you login to.
+    - Saves running-config passwords in clear-text when set to True.
+      Defaults to False
     type: bool
   provider:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #132  - the description for the `passwords` parameter in the documentation is incorrect.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
doc_fragments/asa.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
n/a - It's a documentation issue
