### PR TITLE
updated references of base plugins to netcommon

### DIFF
--- a/changelogs/fragments/netcommon_ref_update.yaml
+++ b/changelogs/fragments/netcommon_ref_update.yaml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - "Minimum required ansible.netcommon version is 2.5.1."
+  - "Updated base plugin references to ansible.netcommon."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Security Community (ansible-security)
 dependencies:
-  "ansible.netcommon": ">=2.0.0"
+  "ansible.netcommon": ">=2.5.1"
 license_file: LICENSE
 name: asa
 namespace: cisco

--- a/plugins/cliconf/asa.py
+++ b/plugins/cliconf/asa.py
@@ -54,7 +54,10 @@ from ansible.module_utils.common._collections_compat import Mapping
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
-from ansible.plugins.cliconf import CliconfBase, enable_mode
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.cliconf_base import (
+    CliconfBase,
+    enable_mode,
+)
 
 
 class Cliconf(CliconfBase):

--- a/plugins/terminal/asa.py
+++ b/plugins/terminal/asa.py
@@ -25,7 +25,9 @@ import json
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text, to_bytes
-from ansible.plugins.terminal import TerminalBase
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import (
+    TerminalBase,
+)
 
 
 class TerminalModule(TerminalBase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Minimum required ansible.netcommon version is 2.5.1
Updated base plugin references to ansible.netcommon

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
