### PR TITLE
Fix Paramiko version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ansible-pylibssh
-paramiko
+paramiko==2.8.1


### PR DESCRIPTION

##### SUMMARY
Paramiko 2.9+ breaks SSH connectivity to older hosts, cisco.ios collection has already downgraded Paramiko to fix:

https://github.com/ansible-collections/cisco.ios/blob/main/requirements.txt

Bug here:

https://github.com/ansible/ansible/issues/76737#issuecomment-1131888013

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
