### PR TITLE
To fix asa_ogs RM port_object range and redundant service command issue

### DIFF
--- a/changelogs/fragments/fix_asa_ogs_bug_165_166.yaml
+++ b/changelogs/fragments/fix_asa_ogs_bug_165_166.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes asa_ogs port object range issue and duplicate service cmd (https://github.com/ansible-collections/cisco.asa/issues/165, https://github.com/ansible-collections/cisco.asa/issues/166).

--- a/plugins/module_utils/network/asa/argspec/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/argspec/ogs/ogs.py
@@ -166,8 +166,6 @@ class OGsArgs(object):
                                 "range": {
                                     "type": "dict",
                                     "options": {
-                                        # "start": {"type": "int"},
-                                        # "end": {"type": "int"},
                                         "start": {"type": "str"},
                                         "end": {"type": "str"},
                                     },

--- a/plugins/module_utils/network/asa/argspec/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/argspec/ogs/ogs.py
@@ -166,8 +166,10 @@ class OGsArgs(object):
                                 "range": {
                                     "type": "dict",
                                     "options": {
-                                        "start": {"type": "int"},
-                                        "end": {"type": "int"},
+                                        # "start": {"type": "int"},
+                                        # "end": {"type": "int"},
+                                        "start": {"type": "str"},
+                                        "end": {"type": "str"},
                                     },
                                 },
                             },

--- a/plugins/module_utils/network/asa/config/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/config/ogs/ogs.py
@@ -411,6 +411,9 @@ class OGs(ResourceModule):
                         entry, h_item, service_obj, ["protocol"]
                     )
                 else:
+                    protocol = entry.get("protocol")
+                    if protocol:
+                        entry["name"] = "{0} {1}".format(name, protocol)
                     self.addcmd(entry, "og_name", False)
                     self.compare(["description"], entry, h_item)
                 if entry.get("group_object"):
@@ -499,13 +502,6 @@ class OGs(ResourceModule):
                         for k, v in iteritems(h_item):
                             temp_have = {"name": name, port_obj: v}
                             self.compare([port_obj], want={}, have=temp_have)
-                    if command_len < len(self.commands):
-                        self.commands.insert(
-                            command_len,
-                            "object-group service {0} {1}".format(
-                                name, protocol
-                            ),
-                        )
         self.check_for_have_and_overidden(have)
 
     def convert_list_to_dict(self, *args, **kwargs):

--- a/plugins/modules/asa_ogs.py
+++ b/plugins/modules/asa_ogs.py
@@ -228,10 +228,10 @@ options:
                 suboptions:
                   start:
                     description: Specify the start of the port range.
-                    type: int
+                    type: str
                   end:
                     description: Specify the end of the port range.
-                    type: int
+                    type: str
           user_object:
             description: Configures single user, local or import user group
             type: dict

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -117,19 +117,6 @@ class TestAsaOGsModule(TestAsaModule):
                     dict(
                         object_groups=[
                             dict(
-                                name="allowed.ports.tcp",
-                                port_object=[
-                                    dict(eq="3300"),
-                                    dict(range=dict(start="9101", end="9103")),
-                                ],
-                                protocol="tcp",
-                            ),
-                        ],
-                        object_type="service",
-                    ),
-                    dict(
-                        object_groups=[
-                            dict(
                                 name="test_user_obj",
                                 user_object=dict(
                                     user_group=[
@@ -175,6 +162,14 @@ class TestAsaOGsModule(TestAsaModule):
                                     )
                                 ],
                             ),
+                            dict(
+                                name="allowed.ports.tcp",
+                                port_object=[
+                                    dict(eq="3300"),
+                                    dict(range=dict(start="9101", end="9103")),
+                                ],
+                                protocol="tcp",
+                            ),
                         ],
                         object_type="service",
                     ),
@@ -195,9 +190,6 @@ class TestAsaOGsModule(TestAsaModule):
             "network-object object NEW_TEST",
             "object-group network bug_test_obj",
             "network-object host 9.9.9.9",
-            "object-group service allowed.ports.tcp tcp",
-            "port-object eq 3300",
-            "port-object range 9101 9103",
             "object-group user test_user_obj",
             "user-group domain\\\\test_merge",
             "object-group protocol test_protocol",
@@ -206,6 +198,9 @@ class TestAsaOGsModule(TestAsaModule):
             "service-object tcp-udp source range 100 200",
             "object-group service test_og_service_dst_port_range",
             "service-object udp destination range 300 400",
+            "object-group service allowed.ports.tcp tcp",
+            "port-object eq 3300",
+            "port-object range 9101 9103",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -117,6 +117,19 @@ class TestAsaOGsModule(TestAsaModule):
                     dict(
                         object_groups=[
                             dict(
+                                name="allowed.ports.tcp",
+                                port_object=[
+                                    dict(eq="3300"),
+                                    dict(range=dict(start="9101", end="9103")),
+                                ],
+                                protocol="tcp",
+                            ),
+                        ],
+                        object_type="service",
+                    ),
+                    dict(
+                        object_groups=[
+                            dict(
                                 name="test_user_obj",
                                 user_object=dict(
                                     user_group=[
@@ -182,6 +195,9 @@ class TestAsaOGsModule(TestAsaModule):
             "network-object object NEW_TEST",
             "object-group network bug_test_obj",
             "network-object host 9.9.9.9",
+            "object-group service allowed.ports.tcp tcp",
+            "port-object eq 3300",
+            "port-object range 9101 9103",
             "object-group user test_user_obj",
             "user-group domain\\\\test_merge",
             "object-group protocol test_protocol",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix asa_ogs RM port_object range and redundant service command issue. Fixes #165 and #166
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_ogs.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
