### PR TITLE
Fixes asa_acls to add the support for network object

### DIFF
--- a/changelogs/fragments/github_actions.yaml
+++ b/changelogs/fragments/github_actions.yaml
@@ -1,0 +1,4 @@
+
+bugfixes:
+  - Fixes asa_acls to add the support for network object under source/destination option
+  - Fix parsing for zero compressed IPv6 addresses

--- a/changelogs/fragments/github_actions.yaml
+++ b/changelogs/fragments/github_actions.yaml
@@ -1,3 +1,4 @@
+---
 bugfixes:
-  - Fixes asa_acls to add the support for network object under source/destination option
-  - Fix parsing for zero compressed IPv6 addresses
+- Fixes asa_acls to add the support for network object under source/destination option
+- Fix parsing for zero compressed IPv6 addresses

--- a/changelogs/fragments/github_actions.yaml
+++ b/changelogs/fragments/github_actions.yaml
@@ -1,4 +1,3 @@
-
 bugfixes:
   - Fixes asa_acls to add the support for network object under source/destination option
   - Fix parsing for zero compressed IPv6 addresses

--- a/changelogs/fragments/github_actions.yaml
+++ b/changelogs/fragments/github_actions.yaml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
 - Fixes asa_acls to add the support for network object under source/destination option
-- Fix parsing for zero compressed IPv6 addresses

--- a/plugins/module_utils/network/asa/argspec/acls/acls.py
+++ b/plugins/module_utils/network/asa/argspec/acls/acls.py
@@ -70,6 +70,7 @@ class AclsArgs(object):
                                         "any6": {"type": "bool"},
                                         "host": {"type": "str"},
                                         "interface": {"type": "str"},
+                                        "network_object": {"type": "str"},
                                         "object_group": {"type": "str"},
                                         "port_protocol": {
                                             "type": "dict",
@@ -101,6 +102,7 @@ class AclsArgs(object):
                                         "any6": {"type": "bool"},
                                         "host": {"type": "str"},
                                         "interface": {"type": "str"},
+                                        "network_object": {"type": "str"},
                                         "object_group": {"type": "str"},
                                         "service_object_group": {
                                             "type": "str"

--- a/plugins/module_utils/network/asa/rm_templates/acls.py
+++ b/plugins/module_utils/network/asa/rm_templates/acls.py
@@ -34,6 +34,10 @@ def _tmplt_access_list_entries(config_data):
                 cmd += " interface {interface}".format(
                     **config_data["aces"][type]
                 )
+            elif config_data["aces"][type].get("network_object"):
+                cmd += " object {network_object}".format(
+                    **config_data["aces"][type]
+                )
             elif config_data["aces"][type].get("object_group"):
                 cmd += " object-group {object_group}".format(
                     **config_data["aces"][type]
@@ -174,9 +178,9 @@ class AclsTemplate(NetworkTemplate):
                     \s*(?P<std_dest>(host\s\S+)|any4|(?:[0-9]{1,3}\.){3}[0-9]{1,3}\s(?:[0-9]{1,3}\.){3}[0-9]{1,3})*
                     \s*(?P<protocol>ah|eigrp|esp|gre|icmp|icmp6|igmp|igrp|ip|ipinip|ipsec|nos|ospf|pcp|pim|pptp|sctp|snp|tcp|udp)*
                     \s*(?P<protocol_num>\d+\s)*
-                    \s*(?P<source>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+))*
+                    \s*(?P<source>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object\s\S+|object-group\s\S+))*
                     \s*(?P<source_port_protocol>(eq|gts|lt|neq)\s(\S+|\d+)|range\s\S+\s\S+)*
-                    \s*(?P<destination>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+))*
+                    \s*(?P<destination>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object\s\S+|object-group\s\S+))*
                     \s*(?P<dest_svc_object_group>object-group\s\S+)*
                     \s*(?P<dest_port_protocol>(eq|gts|lt|neq)\s(\S+|\d+)|range\s\S+\s\S+)*
                     \s*(?P<icmp_icmp6_protocol>alternate-address|conversion-error|echo|echo-reply|information-reply|information-request|mask-reply|mask-request|membership-query|membership-reduction|membership-report|mobile-redirect|neighbor-advertisement|neighbor-redirect|neighbor-solicitation|parameter-problem|packet-too-big|redirect|router-advertisement|router-renumbering|router-solicitation|source-quench|source-route-failed|time-exceeded|timestamp-reply|timestamp-request|traceroute|unreachable)*
@@ -202,15 +206,16 @@ class AclsTemplate(NetworkTemplate):
                                 "icmp_icmp6_protocol": "{{ icmp_icmp6_protocol if icmp_icmp6_protocol is defined else None }}",
                                 "source": {
                                     "address": "{% if source is defined and '.' in source and 'host'\
-                                        not in source and 'object-group' not in source %}{{ source.split(' ')[0] }}{% elif source is defined and\
-                                            '::' in source and 'host' not in source %}{{ source }}{% endif %}",
+                                        not in source and 'object' not in source %}{{ source.split(' ')[0] }}{% elif source is defined and\
+                                            ':' in source and 'host' not in source %}{{ source }}{% endif %}",
                                     "netmask": "{{ source.split(' ')[1] if source\
                                         is defined and '.' in source and 'host' not in source else None and 'object-group' not in source }}",
                                     "any4": "{{ True if source is defined and source == 'any4' else None }}",
                                     "any6": "{{ True if source is defined and source == 'any6' else None }}",
                                     "any": "{{ True if source is defined and source == 'any' else None }}",
-                                    "host": "{{ source.split(' ')[1] if source is defined and 'host' in source else None }}",
+                                    "host": "{{ source.split(' ')[1] if source is defined and source.split(' ')[0] == 'host' else None }}",
                                     "interface": "{{ source.split(' ')[1] if source is defined and 'interface' in source else None }}",
+                                    "network_object": "{{ source.split(' ')[1] if source is defined and source.split(' ')[0] == 'object' else None }}",
                                     "object_group": "{{ source.split(' ')[1] if source is defined and 'object-group' in source else None }}",
                                     "port_protocol": {
                                         "{{ source_port_protocol.split(' ')[0] if source_port_protocol\
@@ -227,9 +232,9 @@ class AclsTemplate(NetworkTemplate):
                                 "destination": {
                                     "address": "{% if destination is defined and 'host' not in destination and\
                                         '.' in destination and\
-                                            'object-group' not in destination %}{{ destination.split(' ')[0] }}{% elif std_dest is defined and\
+                                            'object' not in destination %}{{ destination.split(' ')[0] }}{% elif std_dest is defined and\
                                             '.' in std_dest and 'host' not in std_dest %}{{ std_dest.split(' ')[0] }}{% elif destination is defined and\
-                                                 '::' in destination %}{{ destination }}{% endif %}",
+                                                 ':' in destination %}{{ destination }}{% endif %}",
                                     "netmask": "{% if destination is defined and 'host' not in destination and\
                                         '.' in destination and\
                                              'object-group' not in destination %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
@@ -239,9 +244,10 @@ class AclsTemplate(NetworkTemplate):
                                     "any6": "{{ True if destination is defined and destination == 'any6' else None }}",
                                     "any": "{{ True if destination is defined and destination == 'any' else None }}",
                                     "host": "{% if destination is defined and\
-                                         'host' in destination %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
+                                         destination.split(' ')[0] == 'host' %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
                                               'host' in std_dest %}{{ std_dest.split(' ')[1] }}{% endif %}",
                                     "interface": "{{ destination.split(' ')[1] if destination is defined and 'interface' in destination else None }}",
+                                    "network_object": "{{ destination.split(' ')[1] if destination is defined and destination.split(' ')[0] == 'object' else None }}",
                                     "object_group": "{{ destination.split(' ')[1] if destination is defined and 'object-group' in destination else None }}",
                                     "service_object_group": "{{ dest_svc_object_group.split('object-group ')[1] if dest_svc_object_group is defined }}",
                                     "port_protocol": {

--- a/plugins/module_utils/network/asa/rm_templates/acls.py
+++ b/plugins/module_utils/network/asa/rm_templates/acls.py
@@ -207,7 +207,7 @@ class AclsTemplate(NetworkTemplate):
                                 "source": {
                                     "address": "{% if source is defined and '.' in source and 'host'\
                                         not in source and 'object' not in source %}{{ source.split(' ')[0] }}{% elif source is defined and\
-                                            ':' in source and 'host' not in source %}{{ source }}{% endif %}",
+                                            '::' in source and 'host' not in source %}{{ source }}{% endif %}",
                                     "netmask": "{{ source.split(' ')[1] if source\
                                         is defined and '.' in source and 'host' not in source else None and 'object-group' not in source }}",
                                     "any4": "{{ True if source is defined and source == 'any4' else None }}",
@@ -234,7 +234,7 @@ class AclsTemplate(NetworkTemplate):
                                         '.' in destination and\
                                             'object' not in destination %}{{ destination.split(' ')[0] }}{% elif std_dest is defined and\
                                             '.' in std_dest and 'host' not in std_dest %}{{ std_dest.split(' ')[0] }}{% elif destination is defined and\
-                                                 ':' in destination %}{{ destination }}{% endif %}",
+                                                 '::' in destination %}{{ destination }}{% endif %}",
                                     "netmask": "{% if destination is defined and 'host' not in destination and\
                                         '.' in destination and\
                                              'object-group' not in destination %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\

--- a/plugins/module_utils/network/asa/rm_templates/acls.py
+++ b/plugins/module_utils/network/asa/rm_templates/acls.py
@@ -247,7 +247,8 @@ class AclsTemplate(NetworkTemplate):
                                          destination.split(' ')[0] == 'host' %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
                                               'host' in std_dest %}{{ std_dest.split(' ')[1] }}{% endif %}",
                                     "interface": "{{ destination.split(' ')[1] if destination is defined and 'interface' in destination else None }}",
-                                    "network_object": "{{ destination.split(' ')[1] if destination is defined and destination.split(' ')[0] == 'object' else None }}",
+                                    "network_object": "{{ destination.split(' ')[1] if destination is defined and destination.split(' ')[0] == 'object'\
+                                         else None }}",
                                     "object_group": "{{ destination.split(' ')[1] if destination is defined and 'object-group' in destination else None }}",
                                     "service_object_group": "{{ dest_svc_object_group.split('object-group ')[1] if dest_svc_object_group is defined }}",
                                     "port_protocol": {

--- a/plugins/modules/asa_acls.py
+++ b/plugins/modules/asa_acls.py
@@ -300,6 +300,9 @@ options:
                   interface:
                     description: Use interface address as source address
                     type: str
+                  network_object:
+                    description: Network object for source address
+                    type: str
                   object_group:
                     description: Network object-group for source address
                     type: str
@@ -358,6 +361,9 @@ options:
                     type: str
                   interface:
                     description: Use interface address as destination address
+                    type: str
+                  network_object:
+                    description: Network object for destination address
                     type: str
                   object_group:
                     description: Network object-group for destination address

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -1053,7 +1053,7 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="domain"),
                                     ),
                                     grant="permit",
-                                    line=4,
+                                    line=3,
                                     protocol="udp",
                                     protocol_options=dict(udp="true"),
                                     source=dict(

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -173,64 +173,64 @@ class TestAsaAclsModule(TestAsaModule):
                             acl_type="extended",
                             name="acl_network_object_test",
                         ),
-                        dict(
-                            aces=[
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(
-                                            range=dict(end=200, start=100)
-                                        ),
-                                    ),
-                                    grant="permit",
-                                    line=1,
-                                    protocol="udp",
-                                    protocol_options=dict(udp="true"),
-                                    source=dict(address="2001:db8::/32"),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(eq="www"),
-                                    ),
-                                    grant="permit",
-                                    line=2,
-                                    protocol="tcp",
-                                    protocol_options=dict(tcp="true"),
-                                    source=dict(
-                                        host="2001:db8:85a3:d000:a00:8a2e:370:7334"
-                                    ),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(eq="domain"),
-                                    ),
-                                    grant="permit",
-                                    line=3,
-                                    protocol="udp",
-                                    protocol_options=dict(udp="true"),
-                                    source=dict(
-                                        address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
-                                    ),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        network_object="www_host1",
-                                        port_protocol=dict(eq="www"),
-                                    ),
-                                    grant="permit",
-                                    line=4,
-                                    protocol="tcp",
-                                    protocol_options=dict(tcp="true"),
-                                    source=dict(
-                                        address="2001:db8:85a3::8a2e:370:7334/126"
-                                    ),
-                                ),
-                            ],
-                            acl_type="extended",
-                            name="acl_ipv6_test",
-                        ),
+                        # dict(
+                        #     aces=[
+                        #         dict(
+                        #             destination=dict(
+                        #                 any6="true",
+                        #                 port_protocol=dict(
+                        #                     range=dict(end=200, start=100)
+                        #                 ),
+                        #             ),
+                        #             grant="permit",
+                        #             line=1,
+                        #             protocol="udp",
+                        #             protocol_options=dict(udp="true"),
+                        #             source=dict(address="2001:db8::/32"),
+                        #         ),
+                        #         dict(
+                        #             destination=dict(
+                        #                 any6="true",
+                        #                 port_protocol=dict(eq="www"),
+                        #             ),
+                        #             grant="permit",
+                        #             line=2,
+                        #             protocol="tcp",
+                        #             protocol_options=dict(tcp="true"),
+                        #             source=dict(
+                        #                 host="2001:db8:85a3:d000:a00:8a2e:370:7334"
+                        #             ),
+                        #         ),
+                        #         dict(
+                        #             destination=dict(
+                        #                 any6="true",
+                        #                 port_protocol=dict(eq="domain"),
+                        #             ),
+                        #             grant="permit",
+                        #             line=3,
+                        #             protocol="udp",
+                        #             protocol_options=dict(udp="true"),
+                        #             source=dict(
+                        #                 address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
+                        #             ),
+                        #         ),
+                        #         dict(
+                        #             destination=dict(
+                        #                 network_object="www_host1",
+                        #                 port_protocol=dict(eq="www"),
+                        #             ),
+                        #             grant="permit",
+                        #             line=4,
+                        #             protocol="tcp",
+                        #             protocol_options=dict(tcp="true"),
+                        #             source=dict(
+                        #                 address="2001:db8:85a3::8a2e:370:7334/126"
+                        #             ),
+                        #         ),
+                        #     ],
+                        #     acl_type="extended",
+                        #     name="acl_ipv6_test",
+                        # ),
                     ]
                 ),
                 state="merged",
@@ -244,10 +244,10 @@ class TestAsaAclsModule(TestAsaModule):
             "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
             "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
             "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
-            "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
-            "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
-            "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
-            "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
+            # "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
+            # "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
+            # "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
+            # "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         self.assertEqual(result["commands"], commands)
 

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -127,6 +127,103 @@ class TestAsaAclsModule(TestAsaModule):
                             acl_type="extended",
                             name="MyACL",
                         ),
+                        dict(
+                            aces=[
+                                dict(
+                                    destination=dict(
+                                        any="true",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    line=1,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(network_object="dbhost1"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="www_host1",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    line=2,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(any="true"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="dbhost1",
+                                        port_protocol=dict(eq="5432"),
+                                    ),
+                                    grant="permit",
+                                    line=3,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(host="10.1.2.3"),
+                                ),
+                                dict(
+                                    destination=dict(host="192.168.1.1"),
+                                    grant="permit",
+                                    line=4,
+                                    protocol="icmp",
+                                    source=dict(network_object="dbhost1"),
+                                ),                                                            
+                            ],
+                            acl_type="extended",
+                            name="acl_network_object_test",
+                        ),
+                        dict(
+                            aces=[
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(
+                                            range=dict(
+                                                end=200,
+                                                start=100
+                                            )
+                                        )
+                                    ),
+                                    grant="permit",
+                                    protocol="udp",
+                                    protocol_options=dict(udp="true"),
+                                    source=dict(address="2001:db8::/32"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(host="2001:db8:85a3:d000:a00:8a2e:370:7334"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(eq="domain"),
+                                    ),
+                                    grant="permit",
+                                    protocol="udp",
+                                    protocol_options=dict(udp="true"),
+                                    source=dict(address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="www_host1",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(address="2001:db8:85a3::8a2e:370:7334/126"),
+                                )
+                            ],
+                            acl_type="extended",
+                            name="acl_ipv6_test",
+                        ),
                     ]
                 ),
                 state="merged",
@@ -136,6 +233,14 @@ class TestAsaAclsModule(TestAsaModule):
         commands = [
             "access-list test_global_access line 2 extended deny tcp object-group test_og_network object-group test_network_og eq www log default",
             "access-list MyACL line 2 extended permit tcp object-group O-Environments any object-group O-UNIX-TCP",
+            "access-list acl_network_object_test line 1 extended permit tcp object dbhost1 any eq www",
+            "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
+            "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
+            "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
+            "access-list acl_ipv6_test extended permit udp 2001:db8::/32 any6 range 100 200",
+            "access-list acl_ipv6_test extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
+            "access-list acl_ipv6_test extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
+            "access-list acl_ipv6_test extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         self.assertEqual(result["commands"], commands)
 
@@ -860,14 +965,119 @@ class TestAsaAclsModule(TestAsaModule):
                                     ),
                                 )
                             ],
-                        )
+                        ),
+                        dict(
+                            aces=[
+                                dict(
+                                    destination=dict(
+                                        any="true",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    line=1,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(network_object="dbhost1"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="www_host1",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    line=2,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(any="true"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="dbhost1",
+                                        port_protocol=dict(eq="5432"),
+                                    ),
+                                    grant="permit",
+                                    line=3,
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(host="10.1.2.3"),
+                                ),
+                                dict(
+                                    destination=dict(host="192.168.1.1"),
+                                    grant="permit",
+                                    line=4,
+                                    protocol="icmp",
+                                    source=dict(network_object="dbhost1"),
+                                ),                                                            
+                            ],
+                            acl_type="extended",
+                            name="acl_network_object_test",
+                        ),
+                        dict(
+                            aces=[
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(
+                                            range=dict(
+                                                end=200,
+                                                start=100
+                                            )
+                                        )
+                                    ),
+                                    grant="permit",
+                                    protocol="udp",
+                                    protocol_options=dict(udp="true"),
+                                    source=dict(address="2001:db8::/32"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(host="2001:db8:85a3:d000:a00:8a2e:370:7334"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        any6="true",
+                                        port_protocol=dict(eq="domain"),
+                                    ),
+                                    grant="permit",
+                                    protocol="udp",
+                                    protocol_options=dict(udp="true"),
+                                    source=dict(address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"),
+                                ),
+                                dict(
+                                    destination=dict(
+                                        network_object="www_host1",
+                                        port_protocol=dict(eq="www"),
+                                    ),
+                                    grant="permit",
+                                    protocol="tcp",
+                                    protocol_options=dict(tcp="true"),
+                                    source=dict(address="2001:db8:85a3::8a2e:370:7334/126"),
+                                )
+                            ],
+                            acl_type="extended",
+                            name="acl_ipv6_test",
+                        ),
                     ]
                 ),
                 state="rendered",
             )
         )
         commands = [
-            "access-list test_access line 1 extended deny tcp 192.0.2.0 255.255.255.0 192.0.3.0 255.255.255.0 log default"
+            "access-list test_access line 1 extended deny tcp 192.0.2.0 255.255.255.0 192.0.3.0 255.255.255.0 log default",
+            "access-list acl_network_object_test line 1 extended permit tcp object dbhost1 any eq www",
+            "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
+            "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
+            "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
+            "access-list acl_ipv6_test extended permit udp 2001:db8::/32 any6 range 100 200",
+            "access-list acl_ipv6_test extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
+            "access-list acl_ipv6_test extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
+            "access-list acl_ipv6_test extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(result["rendered"], commands)

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -122,7 +122,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                )
+                                ),
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -173,64 +173,6 @@ class TestAsaAclsModule(TestAsaModule):
                             acl_type="extended",
                             name="acl_network_object_test",
                         ),
-                        # dict(
-                        #     aces=[
-                        #         dict(
-                        #             destination=dict(
-                        #                 any6="true",
-                        #                 port_protocol=dict(
-                        #                     range=dict(end=200, start=100)
-                        #                 ),
-                        #             ),
-                        #             grant="permit",
-                        #             line=1,
-                        #             protocol="udp",
-                        #             protocol_options=dict(udp="true"),
-                        #             source=dict(address="2001:db8::/32"),
-                        #         ),
-                        #         dict(
-                        #             destination=dict(
-                        #                 any6="true",
-                        #                 port_protocol=dict(eq="www"),
-                        #             ),
-                        #             grant="permit",
-                        #             line=2,
-                        #             protocol="tcp",
-                        #             protocol_options=dict(tcp="true"),
-                        #             source=dict(
-                        #                 host="2001:db8:85a3:d000:a00:8a2e:370:7334"
-                        #             ),
-                        #         ),
-                        #         dict(
-                        #             destination=dict(
-                        #                 any6="true",
-                        #                 port_protocol=dict(eq="domain"),
-                        #             ),
-                        #             grant="permit",
-                        #             line=3,
-                        #             protocol="udp",
-                        #             protocol_options=dict(udp="true"),
-                        #             source=dict(
-                        #                 address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
-                        #             ),
-                        #         ),
-                        #         dict(
-                        #             destination=dict(
-                        #                 network_object="www_host1",
-                        #                 port_protocol=dict(eq="www"),
-                        #             ),
-                        #             grant="permit",
-                        #             line=4,
-                        #             protocol="tcp",
-                        #             protocol_options=dict(tcp="true"),
-                        #             source=dict(
-                        #                 address="2001:db8:85a3::8a2e:370:7334/126"
-                        #             ),
-                        #         ),
-                        #     ],
-                        #     acl_type="extended",
-                        #     name="acl_ipv6_test",
-                        # ),
                     ]
                 ),
                 state="merged",
@@ -244,10 +186,6 @@ class TestAsaAclsModule(TestAsaModule):
             "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
             "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
             "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
-            # "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
-            # "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
-            # "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
-            # "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         self.assertEqual(result["commands"], commands)
 
@@ -392,7 +330,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                )
+                                ),
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -632,7 +570,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                )
+                                ),
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -865,7 +803,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                )
+                                ),
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -1019,64 +957,6 @@ class TestAsaAclsModule(TestAsaModule):
                             acl_type="extended",
                             name="acl_network_object_test",
                         ),
-                        dict(
-                            aces=[
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(
-                                            range=dict(end=200, start=100)
-                                        ),
-                                    ),
-                                    grant="permit",
-                                    line=1,
-                                    protocol="udp",
-                                    protocol_options=dict(udp="true"),
-                                    source=dict(address="2001:db8::/32"),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(eq="www"),
-                                    ),
-                                    grant="permit",
-                                    line=2,
-                                    protocol="tcp",
-                                    protocol_options=dict(tcp="true"),
-                                    source=dict(
-                                        host="2001:db8:85a3:d000:a00:8a2e:370:7334"
-                                    ),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        any6="true",
-                                        port_protocol=dict(eq="domain"),
-                                    ),
-                                    grant="permit",
-                                    line=3,
-                                    protocol="udp",
-                                    protocol_options=dict(udp="true"),
-                                    source=dict(
-                                        address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
-                                    ),
-                                ),
-                                dict(
-                                    destination=dict(
-                                        network_object="www_host1",
-                                        port_protocol=dict(eq="www"),
-                                    ),
-                                    grant="permit",
-                                    line=4,
-                                    protocol="tcp",
-                                    protocol_options=dict(tcp="true"),
-                                    source=dict(
-                                        address="2001:db8:85a3::8a2e:370:7334/126"
-                                    ),
-                                ),
-                            ],
-                            acl_type="extended",
-                            name="acl_ipv6_test",
-                        ),
                     ]
                 ),
                 state="rendered",
@@ -1088,10 +968,6 @@ class TestAsaAclsModule(TestAsaModule):
             "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
             "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
             "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
-            "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
-            "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
-            "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
-            "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(result["rendered"], commands)

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -122,7 +122,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                ),
+                                )
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -168,7 +168,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     line=4,
                                     protocol="icmp",
                                     source=dict(network_object="dbhost1"),
-                                ),                                                            
+                                ),
                             ],
                             acl_type="extended",
                             name="acl_network_object_test",
@@ -179,13 +179,11 @@ class TestAsaAclsModule(TestAsaModule):
                                     destination=dict(
                                         any6="true",
                                         port_protocol=dict(
-                                            range=dict(
-                                                end=200,
-                                                start=100
-                                            )
-                                        )
+                                            range=dict(end=200, start=100)
+                                        ),
                                     ),
                                     grant="permit",
+                                    line=1,
                                     protocol="udp",
                                     protocol_options=dict(udp="true"),
                                     source=dict(address="2001:db8::/32"),
@@ -196,9 +194,12 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="www"),
                                     ),
                                     grant="permit",
+                                    line=2,
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
-                                    source=dict(host="2001:db8:85a3:d000:a00:8a2e:370:7334"),
+                                    source=dict(
+                                        host="2001:db8:85a3:d000:a00:8a2e:370:7334"
+                                    ),
                                 ),
                                 dict(
                                     destination=dict(
@@ -206,9 +207,12 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="domain"),
                                     ),
                                     grant="permit",
+                                    line=3,
                                     protocol="udp",
                                     protocol_options=dict(udp="true"),
-                                    source=dict(address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"),
+                                    source=dict(
+                                        address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
+                                    ),
                                 ),
                                 dict(
                                     destination=dict(
@@ -216,10 +220,13 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="www"),
                                     ),
                                     grant="permit",
+                                    line=4,
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
-                                    source=dict(address="2001:db8:85a3::8a2e:370:7334/126"),
-                                )
+                                    source=dict(
+                                        address="2001:db8:85a3::8a2e:370:7334/126"
+                                    ),
+                                ),
                             ],
                             acl_type="extended",
                             name="acl_ipv6_test",
@@ -237,10 +244,10 @@ class TestAsaAclsModule(TestAsaModule):
             "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
             "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
             "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
-            "access-list acl_ipv6_test extended permit udp 2001:db8::/32 any6 range 100 200",
-            "access-list acl_ipv6_test extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
-            "access-list acl_ipv6_test extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
-            "access-list acl_ipv6_test extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
+            "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
+            "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
+            "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
+            "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         self.assertEqual(result["commands"], commands)
 
@@ -385,7 +392,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                ),
+                                )
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -625,7 +632,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                ),
+                                )
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -858,7 +865,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
                                     source=dict(object_group="O-Environments"),
-                                ),
+                                )
                             ],
                             acl_type="extended",
                             name="MyACL",
@@ -1007,7 +1014,7 @@ class TestAsaAclsModule(TestAsaModule):
                                     line=4,
                                     protocol="icmp",
                                     source=dict(network_object="dbhost1"),
-                                ),                                                            
+                                ),
                             ],
                             acl_type="extended",
                             name="acl_network_object_test",
@@ -1018,13 +1025,11 @@ class TestAsaAclsModule(TestAsaModule):
                                     destination=dict(
                                         any6="true",
                                         port_protocol=dict(
-                                            range=dict(
-                                                end=200,
-                                                start=100
-                                            )
-                                        )
+                                            range=dict(end=200, start=100)
+                                        ),
                                     ),
                                     grant="permit",
+                                    line=1,
                                     protocol="udp",
                                     protocol_options=dict(udp="true"),
                                     source=dict(address="2001:db8::/32"),
@@ -1035,9 +1040,12 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="www"),
                                     ),
                                     grant="permit",
+                                    line=2,
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
-                                    source=dict(host="2001:db8:85a3:d000:a00:8a2e:370:7334"),
+                                    source=dict(
+                                        host="2001:db8:85a3:d000:a00:8a2e:370:7334"
+                                    ),
                                 ),
                                 dict(
                                     destination=dict(
@@ -1045,9 +1053,12 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="domain"),
                                     ),
                                     grant="permit",
+                                    line=4,
                                     protocol="udp",
                                     protocol_options=dict(udp="true"),
-                                    source=dict(address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"),
+                                    source=dict(
+                                        address="2001:db8:85a3:d000:a00:8a2e:370:7334/127"
+                                    ),
                                 ),
                                 dict(
                                     destination=dict(
@@ -1055,10 +1066,13 @@ class TestAsaAclsModule(TestAsaModule):
                                         port_protocol=dict(eq="www"),
                                     ),
                                     grant="permit",
+                                    line=4,
                                     protocol="tcp",
                                     protocol_options=dict(tcp="true"),
-                                    source=dict(address="2001:db8:85a3::8a2e:370:7334/126"),
-                                )
+                                    source=dict(
+                                        address="2001:db8:85a3::8a2e:370:7334/126"
+                                    ),
+                                ),
                             ],
                             acl_type="extended",
                             name="acl_ipv6_test",
@@ -1074,10 +1088,10 @@ class TestAsaAclsModule(TestAsaModule):
             "access-list acl_network_object_test line 2 extended permit tcp any object www_host1 eq www",
             "access-list acl_network_object_test line 3 extended permit tcp host 10.1.2.3 object dbhost1 eq 5432",
             "access-list acl_network_object_test line 4 extended permit icmp object dbhost1 host 192.168.1.1",
-            "access-list acl_ipv6_test extended permit udp 2001:db8::/32 any6 range 100 200",
-            "access-list acl_ipv6_test extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
-            "access-list acl_ipv6_test extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
-            "access-list acl_ipv6_test extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
+            "access-list acl_ipv6_test line 1 extended permit udp 2001:db8::/32 any6 range 100 200",
+            "access-list acl_ipv6_test line 2 extended permit tcp host 2001:db8:85a3:d000:a00:8a2e:370:7334 any6 eq www",
+            "access-list acl_ipv6_test line 3 extended permit udp 2001:db8:85a3:d000:a00:8a2e:370:7334/127 any6 eq domain",
+            "access-list acl_ipv6_test line 4 extended permit tcp 2001:db8:85a3::8a2e:370:7334/126 object www_host1 eq www",
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(result["rendered"], commands)


### PR DESCRIPTION
  - Fixes asa_acls to add the support for network object under source/destination option
  - Fix parsing for zero compressed IPv6 addresses

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Add support for network object as src/dst option
2. Fixing ipv6 ace parsing which contains uncompressed ipv6 address (does not contain :: in it)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cisco.asa.asa_acls

##### ADDITIONAL INFORMATION
ACL entries which contains objects can not be parsed correctly as wall as such aces can't be defined.

```
