### PR TITLE
Added a switch to toggle the sort function in the OGs Module

### DIFF
--- a/plugins/module_utils/network/asa/argspec/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/argspec/ogs/ogs.py
@@ -244,6 +244,7 @@ class OGsArgs(object):
             },
         },
         "running_config": {"type": "str"},
+        "sortgroups": {"type": "bool", "default" : True},
         "state": {
             "choices": [
                 "merged",

--- a/plugins/module_utils/network/asa/facts/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/facts/ogs/ogs.py
@@ -86,10 +86,12 @@ class OGsFacts(object):
                         obj_gp[object_groups.get(k)] = each[1]
                     config_dict["object_groups"].append(obj_gp)
                     obj_gp = {}
-                config_dict["object_groups"] = sorted(
-                    config_dict["object_groups"],
-                    key=lambda k, sk="name": str(k[sk]),
-                )
+                sortgroups = self._module.params.get("sortgroups", True)
+                if sortgroups:
+                    config_dict["object_groups"] = sorted(
+                        config_dict["object_groups"],
+                        key=lambda k, sk="name": str(k[sk]),
+                    )
                 ogs.append(config_dict)
         # sort the object group list of dict by object_type
         ogs = sorted(ogs, key=lambda i: i["object_type"])

--- a/plugins/modules/asa_ogs.py
+++ b/plugins/modules/asa_ogs.py
@@ -277,6 +277,13 @@ options:
       value of this option should be the output received from device by executing
       command.
     type: str
+  sortgroups:
+    description:
+    - The module, by default, will sort all outputted groups by alphabet. There are times
+      when it is not desirable to have the groups sorted. Example: You want to use the output
+      from state 'gathered' as input for the state 'replaced' (the groups have dependencies
+      to each other, so they have to be configured in the correct order).
+    type: boolean
   state:
     description:
     - The state the configuration should be left in
@@ -1062,7 +1069,7 @@ def main():
         ("state", "parsed", ("running_config",)),
     ]
 
-    mutually_exclusive = [("config", "running_config")]
+    mutually_exclusive = [("config", "running_config","sortgroups")]
 
     module = AnsibleModule(
         argument_spec=OGsArgs.argument_spec,


### PR DESCRIPTION
##### SUMMARY
Added a switch to toggle the sort function. Before always all groups from state 'gathered' got sorted. Now you can toggle it. 
It is useful when you want to use the output from 'gathered' as input for 'replaced'. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- Gathered Sort Switch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: Gather listed OGs with provided configurations
    cisco.asa.asa_ogs:
      sortgroups: false
      state: gathered
```
