### PR TITLE
Fix NetworkTemplate import (fix #195)

### DIFF
--- a/changelogs/fragments/rm_base_plus.yaml
+++ b/changelogs/fragments/rm_base_plus.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Move remaining references for ResourceModule to the rm_base package as the non-rm_base path is going away. (https://github.com/ansible-collections/ansible.netcommon/pull/496)

--- a/plugins/module_utils/network/asa/facts/acls/acls.py
+++ b/plugins/module_utils/network/asa/facts/acls/acls.py
@@ -26,7 +26,7 @@ from ansible_collections.cisco.asa.plugins.module_utils.network.asa.argspec.acls
 from ansible_collections.cisco.asa.plugins.module_utils.network.asa.rm_templates.acls import (
     AclsTemplate,
 )
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network_template import (
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.network_template import (
     NetworkTemplate,
 )
 

--- a/plugins/module_utils/network/asa/facts/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/facts/ogs/ogs.py
@@ -24,7 +24,7 @@ from ansible_collections.cisco.asa.plugins.module_utils.network.asa.argspec.ogs.
 from ansible_collections.cisco.asa.plugins.module_utils.network.asa.rm_templates.ogs import (
     OGsTemplate,
 )
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network_template import (
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.network_template import (
     NetworkTemplate,
 )
 

--- a/plugins/module_utils/network/asa/utils/utils.py
+++ b/plugins/module_utils/network/asa/utils/utils.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 import socket
 from ansible.module_utils.six import iteritems
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+from ansible.module_utils.common.network import (
     is_masklen,
     to_netmask,
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

From [ansible.netcommon](https://github.com/ansible-collections/ansible.netcommon/blob/main/CHANGELOG.rst#id60) 5.0.0 change log:

```
NetworkTemplate is no longer importable from ansible_collections.ansible.netcommon.plugins.module_utils.network.common and should now be found at its proper location ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.network_template
```

This PR corrects these imports. It might fix #195 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.asa.asa_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Running cisco.asa 4.0.0 with ansible.netcommon 5.0.0 fails due to incorrect library imports

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network_template'
fatal: [localhost]: FAILED! => {"msg": "Unexpected failure during module execution: No module named 'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network_template'", "stdout": ""}
```
