### PR TITLE
README: Add Communication section with Forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Ansible Cisco ASA collection includes a variety of Ansible content to help a
 
 * Join the Ansible forum:
   * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  * [Posts tagged with 'your tag'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
+  * [Posts tagged with 'security'](https://forum.ansible.com/tag/security): subscribe to participate in collection-related conversations.
   * [Ansible Network Automation Working Group](https://forum.ansible.com/g/network-wg): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags/security).
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 The Ansible Cisco ASA collection includes a variety of Ansible content to help automate the management of Cisco ASA firewall appliances.
 
+## Communication
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [Posts tagged with 'your tag'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
+  * [Refer to your forum group here if exists](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 <!--start requires_ansible-->
 ## Ansible version compatibility
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Ansible Cisco ASA collection includes a variety of Ansible content to help a
 * Join the Ansible forum:
   * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
   * [Posts tagged with 'your tag'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection-related conversations.
-  * [Refer to your forum group here if exists](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
+  * [Ansible Network Automation Working Group](https://forum.ansible.com/g/network-wg): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags/security).
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 

--- a/changelogs/fragments/0-readme.yml
+++ b/changelogs/fragments/0-readme.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - README.md - Add Communication section with Forum information.


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

- If you have your forum group and/or tags related to the collection, please update corresponding lines by suggesting changes to the PR.
- If the collection is not present on the Ansible forum yet, please check out the existing [tags](https://forum.ansible.com/tags) and [groups](https://forum.ansible.com/g) - use what suits your collection. If there is no appropritate tag and group yet, please [request one](https://forum.ansible.com/t/requesting-a-forum-group/503/17). Then update corresponding lines by suggesting changes to the PR.
- Presence in the forum will soon likely become a part of the Collection inclusion requirements.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md