### PR TITLE
tests/sanity/ignore-2.21.txt: fix sanity tests for dev/milestone

### DIFF
--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/action/asa.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`


### PR DESCRIPTION


##### SUMMARY
CI sanity tests were [failing for sanity-py3.12-devel, sanity-py3.12-milestone, sanity-py3.13-devel, and sanity-py3.13-milestone](https://github.com/ansible-collections/cisco.asa/actions/runs/21846821563).

In the Ansible Forum @felixfontein recommended: [If you copy tests/sanity/ignore-2.20.txt over to tests/sanity/ignore-2.21.txt this should go away.](https://forum.ansible.com/t/announcing-a-change-in-support-for-cisco-asa-transitioning-to-community-maintenance/44482/5?u=mistertom)

tests/sanity/ignore-2.21.txt: fixes sanity tests for dev/milestone (copy ignore-2.20.txt to fix CI)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/sanity/ignore-2.21.txt

##### ADDITIONAL INFORMATION
CI Failures which I'm trying to resolve can be viewed here: https://github.com/ansible-collections/cisco.asa/actions/workflows/tests.yml 
Screenshot from drilldown detail of the failed sanity tests errors.
<img width="377" height="351" alt="cisco-asa_sanity-test_devel-milestone_2026-02-09_202645" src="https://github.com/user-attachments/assets/ac673242-6280-4871-82d8-fe08c68c5c5c" />
