### PR TITLE
asa_acls: support referencing network objects directly

### DIFF
--- a/changelogs/fragments/asa_acls_object_support.yaml
+++ b/changelogs/fragments/asa_acls_object_support.yaml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - asa_acls - add support for referencing a network object directly in an ACE
+    source or destination with the new ``object`` option. Previously only
+    ``object_group`` was available, so ``object <name>`` entries on the device were
+    silently dropped when gathering facts, leaving the affected entries without a
+    source or destination.

--- a/docs/cisco.asa.asa_acls_module.rst
+++ b/docs/cisco.asa.asa_acls_module.rst
@@ -253,6 +253,25 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>object</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Network object for destination address</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>object_group</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -2075,6 +2094,25 @@ Parameters
                 </td>
                 <td>
                         <div>Netmask for source IP address, valid with IPV4 address.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>object</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Network object for source address</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/module_utils/network/asa/argspec/acls/acls.py
+++ b/plugins/module_utils/network/asa/argspec/acls/acls.py
@@ -71,6 +71,7 @@ class AclsArgs(object):
                                         "any6": {"type": "bool"},
                                         "host": {"type": "str"},
                                         "interface": {"type": "str"},
+                                        "object": {"type": "str"},
                                         "object_group": {"type": "str"},
                                         "port_protocol": {
                                             "type": "dict",
@@ -102,6 +103,7 @@ class AclsArgs(object):
                                         "any6": {"type": "bool"},
                                         "host": {"type": "str"},
                                         "interface": {"type": "str"},
+                                        "object": {"type": "str"},
                                         "object_group": {"type": "str"},
                                         "service_object_group": {
                                             "type": "str",

--- a/plugins/module_utils/network/asa/rm_templates/acls.py
+++ b/plugins/module_utils/network/asa/rm_templates/acls.py
@@ -34,6 +34,8 @@ def _tmplt_access_list_entries(config_data):
                 cmd += " host {host}".format(**config_data["aces"][type])
             elif config_data["aces"][type].get("interface"):
                 cmd += " interface {interface}".format(**config_data["aces"][type])
+            elif config_data["aces"][type].get("object"):
+                cmd += " object {object}".format(**config_data["aces"][type])
             elif config_data["aces"][type].get("object_group"):
                 cmd += " object-group {object_group}".format(**config_data["aces"][type])
             if type == "destination" and config_data["aces"][type].get(
@@ -155,9 +157,9 @@ class AclsTemplate(NetworkTemplate):
                     \s*(?P<std_dest>(host\s\S+)|any4|(?:[0-9]{1,3}\.){3}[0-9]{1,3}\s(?:[0-9]{1,3}\.){3}[0-9]{1,3})*
                     \s*(?P<protocol>ah|eigrp|esp|gre|icmp|icmp6|igmp|igrp|ip|ipinip|ipsec|nos|ospf|pcp|pim|pptp|sctp|snp|tcp|udp|object-group\s\S+)*
                     \s*(?P<protocol_num>\d+\s)*
-                    \s*(?P<source>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+))*
+                    \s*(?P<source>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+|object\s\S+))*
                     \s*(?P<source_port_protocol>(eq|gts|lt|neq)\s(\S+|\d+)|range\s\S+\s\S+)*
-                    \s*(?P<destination>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+))*
+                    \s*(?P<destination>any4|any6|any|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+\S+|host\s(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})|(([a-f0-9:]+:+)+[a-f0-9]+)\S+)|interface\s\S+|object-group\s\S+|object\s\S+))*
                     \s*(?P<dest_svc_object_group>object-group\s\S+)*
                     \s*(?P<dest_port_protocol>(eq|gts|lt|neq)\s(\S+|\d+)|range\s\S+\s\S+)*
                     \s*(?P<icmp_icmp6_protocol>alternate-address|conversion-error|echo|echo-reply|information-reply|information-request|mask-reply|mask-request|membership-query|membership-reduction|membership-report|mobile-redirect|neighbor-advertisement|neighbor-redirect|neighbor-solicitation|parameter-problem|packet-too-big|redirect|router-advertisement|router-renumbering|router-solicitation|source-quench|source-route-failed|time-exceeded|timestamp-reply|timestamp-request|traceroute|unreachable)*
@@ -183,15 +185,18 @@ class AclsTemplate(NetworkTemplate):
                                 "icmp_icmp6_protocol": "{{ icmp_icmp6_protocol if icmp_icmp6_protocol is defined else None }}",
                                 "source": {
                                     "address": "{% if source is defined and '.' in source and 'host'\
-                                        not in source and 'object-group' not in source %}{{ source.split(' ')[0] }}{% elif source is defined and\
+                                        not in source and 'object-group' not in source\
+                                        and not source.startswith('object ') %}{{ source.split(' ')[0] }}{% elif source is defined and\
                                             '::' in source and 'host' not in source %}{{ source }}{% endif %}",
                                     "netmask": "{{ source.split(' ')[1] if source\
-                                        is defined and '.' in source and 'host' not in source and 'object-group' not in source else None }}",
+                                        is defined and '.' in source and 'host' not in source and 'object-group' not in source\
+                                        and not source.startswith('object ') else None }}",
                                     "any4": "{{ True if source is defined and source == 'any4' else None }}",
                                     "any6": "{{ True if source is defined and source == 'any6' else None }}",
                                     "any": "{{ True if source is defined and source == 'any' else None }}",
                                     "host": "{{ source.split(' ')[1] if source is defined and 'host' in source else None }}",
                                     "interface": "{{ source.split(' ')[1] if source is defined and 'interface' in source else None }}",
+                                    "object": "{{ source.split(' ')[1] if source is defined and source.startswith('object ') else None }}",
                                     "object_group": "{{ source.split(' ')[1] if source is defined and 'object-group' in source else None }}",
                                     "port_protocol": {
                                         "{{ source_port_protocol.split(' ')[0] if source_port_protocol\
@@ -208,12 +213,14 @@ class AclsTemplate(NetworkTemplate):
                                 "destination": {
                                     "address": "{% if destination is defined and 'host' not in destination and\
                                         '.' in destination and\
-                                            'object-group' not in destination %}{{ destination.split(' ')[0] }}{% elif std_dest is defined and\
+                                            'object-group' not in destination and\
+                                            not destination.startswith('object ') %}{{ destination.split(' ')[0] }}{% elif std_dest is defined and\
                                             '.' in std_dest and 'host' not in std_dest %}{{ std_dest.split(' ')[0] }}{% elif destination is defined and\
                                                  '::' in destination %}{{ destination }}{% endif %}",
                                     "netmask": "{% if destination is defined and 'host' not in destination and\
                                         '.' in destination and\
-                                             'object-group' not in destination %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
+                                             'object-group' not in destination and\
+                                             not destination.startswith('object ') %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
                                              '.' in std_dest and 'host' not in std_dest %}{{ std_dest.split(' ')[1] }}{% endif %}",
                                     "any4": "{% if destination is defined and\
                                          destination == 'any4' %}{{ True }}{% elif std_dest is defined and std_dest == 'any4' %}{{ True }}{% endif %}",
@@ -223,6 +230,7 @@ class AclsTemplate(NetworkTemplate):
                                          'host' in destination %}{{ destination.split(' ')[1] }}{% elif std_dest is defined and\
                                               'host' in std_dest %}{{ std_dest.split(' ')[1] }}{% endif %}",
                                     "interface": "{{ destination.split(' ')[1] if destination is defined and 'interface' in destination else None }}",
+                                    "object": "{{ destination.split(' ')[1] if destination is defined and destination.startswith('object ') else None }}",
                                     "object_group": "{{ destination.split(' ')[1] if destination is defined and 'object-group' in destination else None }}",
                                     "service_object_group": "{{ dest_svc_object_group.split('object-group ')[1] if dest_svc_object_group is defined }}",
                                     "port_protocol": {

--- a/plugins/modules/asa_acls.py
+++ b/plugins/modules/asa_acls.py
@@ -301,6 +301,9 @@ options:
                   interface:
                     description: Use interface address as source address
                     type: str
+                  object:
+                    description: Network object for source address
+                    type: str
                   object_group:
                     description: Network object-group for source address
                     type: str
@@ -359,6 +362,9 @@ options:
                     type: str
                   interface:
                     description: Use interface address as destination address
+                    type: str
+                  object:
+                    description: Network object for destination address
                     type: str
                   object_group:
                     description: Network object-group for destination address

--- a/tests/unit/modules/network/asa/test_asa_acls.py
+++ b/tests/unit/modules/network/asa/test_asa_acls.py
@@ -1292,3 +1292,147 @@ class TestAsaAclsModule(TestAsaModule):
         }
         result = self.execute_module(changed=False)
         self.assertEqual(result["gathered"], facts)
+
+    def test_asa_acls_object_gathered(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            access-list test_obj; 4 elements; name hash: 0xbd6c87a7
+            access-list test_obj line 1 remark test object remark
+            access-list test_obj line 2 extended permit udp object test_src object-group test_og eq ntp log informational (hitcnt=0) 0xf1efa630
+            access-list test_obj line 3 extended permit object-group test_svc object-group test_og object test_dst log informational (hitcnt=0) 0xae5833af
+            access-list test_obj line 4 extended permit ip object test_src object test_dst (hitcnt=0) 0x4a4660f3
+            """,
+        )
+        set_module_args(
+            dict(
+                state="gathered",
+            ),
+        )
+        facts = {
+            "acls": [
+                {
+                    "name": "test_obj",
+                    "acl_type": "extended",
+                    "aces": [
+                        {"line": 1, "remark": "test object remark"},
+                        {
+                            "grant": "permit",
+                            "line": 2,
+                            "protocol": "udp",
+                            "protocol_options": {"udp": True},
+                            "source": {"object": "test_src"},
+                            "destination": {
+                                "object_group": "test_og",
+                                "port_protocol": {"eq": "ntp"},
+                            },
+                            "log": "informational",
+                        },
+                        {
+                            "grant": "permit",
+                            "line": 3,
+                            "protocol": "object-group test_svc",
+                            "source": {"object_group": "test_og"},
+                            "destination": {"object": "test_dst"},
+                            "log": "informational",
+                        },
+                        {
+                            "grant": "permit",
+                            "line": 4,
+                            "protocol": "ip",
+                            "protocol_options": {"ip": True},
+                            "source": {"object": "test_src"},
+                            "destination": {"object": "test_dst"},
+                        },
+                    ],
+                },
+            ],
+        }
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["gathered"], facts)
+
+    def test_asa_acls_object_rendered(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    acls=[
+                        dict(
+                            name="test_obj",
+                            acl_type="extended",
+                            aces=[
+                                dict(
+                                    grant="permit",
+                                    line=1,
+                                    protocol_options=dict(udp=True),
+                                    source=dict(object="test_src"),
+                                    destination=dict(
+                                        object_group="test_og",
+                                        port_protocol=dict(eq="ntp"),
+                                    ),
+                                    log="informational",
+                                ),
+                                dict(
+                                    grant="permit",
+                                    line=2,
+                                    protocol_options=dict(ip=True),
+                                    source=dict(object="test_src"),
+                                    destination=dict(object="test_dst"),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="rendered",
+            ),
+        )
+        commands = [
+            "access-list test_obj line 1 extended permit udp object test_src"
+            " object-group test_og eq ntp log informational",
+            "access-list test_obj line 2 extended permit ip object test_src object test_dst",
+        ]
+        result = self.execute_module(changed=False)
+        self.assertEqual(sorted(result["rendered"]), sorted(commands))
+
+    def test_asa_acls_object_merged_idempotent(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            access-list test_obj; 2 elements; name hash: 0xbd6c87a7
+            access-list test_obj line 1 extended permit udp object test_src object-group test_og eq ntp log informational (hitcnt=0) 0xf1efa630
+            access-list test_obj line 2 extended permit ip object test_src object test_dst (hitcnt=0) 0x4a4660f3
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    acls=[
+                        dict(
+                            name="test_obj",
+                            acl_type="extended",
+                            aces=[
+                                dict(
+                                    grant="permit",
+                                    line=1,
+                                    protocol="udp",
+                                    protocol_options=dict(udp=True),
+                                    source=dict(object="test_src"),
+                                    destination=dict(
+                                        object_group="test_og",
+                                        port_protocol=dict(eq="ntp"),
+                                    ),
+                                    log="informational",
+                                ),
+                                dict(
+                                    grant="permit",
+                                    line=2,
+                                    protocol="ip",
+                                    protocol_options=dict(ip=True),
+                                    source=dict(object="test_src"),
+                                    destination=dict(object="test_dst"),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        self.execute_module(changed=False, commands=[])


### PR DESCRIPTION
##### SUMMARY

`asa_acls` has no way to reference a network *object* in an ACE source or destination — only `object_group`. The ACE parser therefore does not match `object <name>`, and because the parser is a single sequential regex, the failure cascades: everything after the unmatched token (destination, ports, `log`) is dropped too.

On a device whose ACL uses objects, the effect is that most entries come back from `gathered` with no source and no destination at all. For example:

```
access-list global-policy-ewr2 extended permit udp object ewr2-mgmt object-group dnb-ntp eq ntp log
```

is gathered as `{grant: permit, line: 2, protocol: udp}`.

That also makes the module non-idempotent on such a device. `_compare` pairs a wanted entry to an existing one using only `(source, destination)`, so entries that all collapse onto an empty pair are mispaired. On a real 34-entry ACL this produced 4 spurious commands under `merged` and 46 under `replaced` with the golden config generated from the module's own `gathered` output and nothing changed on the device.

This PR adds an `object` option to ACE `source` and `destination`, mirroring the existing `object_group` handling in the argspec, the parser and the renderer.

Measured on that same 34-entry ACL, before → after:

| | before | after |
|---|---|---|
| rules with source preserved | 4/17 | 17/17 |
| rules with destination preserved | 1/17 | 17/17 |
| distinct `(source, destination)` keys | 5 | 18 |
| `merged` / `replaced` / `overridden` when in sync | 4 / 46 / 46 commands | 0 / 0 / 0 |

One change touches existing conditions: the `address`/`netmask` branches trigger on `'.' in source`, so an object name containing a dot (e.g. `object mq-host.example.net`) was parsed as an address/netmask pair. They are now guarded against `object `, mirroring the existing `'object-group' not in source` guards.

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

asa_acls

##### ADDITIONAL INFORMATION

Before:

```yaml
- cisco.asa.asa_acls:
    state: gathered
# gathered:
#   acls:
#     - name: global-policy-ewr2
#       acl_type: extended
#       aces:
#         - grant: permit
#           line: 2
#           protocol: udp          # source, destination, port and log all lost
```

After:

```yaml
- cisco.asa.asa_acls:
    config:
      acls:
        - name: global-policy-ewr2
          acl_type: extended
          aces:
            - grant: permit
              line: 2
              protocol: udp
              source:
                object: ewr2-mgmt
              destination:
                object_group: dnb-ntp
                port_protocol:
                  eq: ntp
              log: informational
    state: merged
# access-list global-policy-ewr2 line 2 extended permit udp object ewr2-mgmt object-group dnb-ntp eq ntp log informational
```

Testing done:

- 3 new unit tests (`gathered`, `rendered`, `merged` idempotent) covering objects in source and destination, mixed `object`/`object_group` on one entry, and a service object-group in the protocol position. Full unit suite passes (24).
- `ansible-test sanity` passes on the changed files.
- Verified against a live ASA 9.x: a 34-entry ACL using objects now reports `changed=0` in check mode, where it previously rewrote the whole ACL.

Integration tests were not run — no lab device available.
