### PR TITLE
Fix asa_ogs missing object-group context when adding new element type

### DIFF
--- a/changelogs/fragments/fix_ogs_add_object_cmd_273.yaml
+++ b/changelogs/fragments/fix_ogs_add_object_cmd_273.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - asa_ogs - fix _add_object_cmd not emitting object-group context command when adding a new element type to an existing group, causing Invalid input detected error (https://github.com/ansible-collections/cisco.asa/issues/273)

--- a/plugins/module_utils/network/asa/config/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/config/ogs/ogs.py
@@ -590,12 +590,14 @@ class OGs(ResourceModule):
                 and isinstance(want_element, list)
                 and isinstance(want_element[0], dict)
             ):
-                if want_element and have_element and want_element != have_element:
+                if want_element and want_element != have_element:
                     if not obj_cmd_added:
                         self.addcmd(want, "og_name", False)
                         obj_cmd_added = True
             else:
-                if want_element and have_element and set(want_element) != set(have_element):
+                if want_element and (
+                    not have_element or set(want_element) != set(have_element)
+                ):
                     if not obj_cmd_added:
                         self.addcmd(want, "og_name", False)
                         obj_cmd_added = True

--- a/plugins/module_utils/network/asa/config/ogs/ogs.py
+++ b/plugins/module_utils/network/asa/config/ogs/ogs.py
@@ -595,9 +595,7 @@ class OGs(ResourceModule):
                         self.addcmd(want, "og_name", False)
                         obj_cmd_added = True
             else:
-                if want_element and (
-                    not have_element or set(want_element) != set(have_element)
-                ):
+                if want_element and (not have_element or set(want_element) != set(have_element)):
                     if not obj_cmd_added:
                         self.addcmd(want, "og_name", False)
                         obj_cmd_added = True

--- a/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
+++ b/tests/unit/modules/network/asa/fixtures/asa_ogs_config.cfg
@@ -39,3 +39,5 @@ object-group user group_user_obj
 object-group protocol test_protocol
  protocol-object 16
 object-group network bug_test_obj
+object-group network object_only_group
+  network-object object TEST1

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -325,6 +325,35 @@ class TestAsaOGsModule(TestAsaModule):
         )
         self.execute_module(changed=False, commands=[], sort=True)
 
+    def test_asa_ogs_merged_new_element_type(self):
+        """Regression test for issue #273: adding a new element type to an
+        existing group must emit the object-group context command first."""
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        object_groups=[
+                            dict(
+                                name="object_only_group",
+                                network_object=dict(
+                                    object=["TEST1"],
+                                    host=["1.2.3.4"],
+                                ),
+                            ),
+                        ],
+                        object_type="network",
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "object-group network object_only_group",
+            "network-object host 1.2.3.4",
+        ]
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
     def test_asa_ogs_replaced(self):
         set_module_args(
             dict(
@@ -532,6 +561,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no object-group network ANSIBLE_TEST",
             "no object-group network bug_test_obj",
             "no object-group network mixed_og_network",
+            "no object-group network object_only_group",
             "no object-group user group_user_obj",
             "no object-group user test_user_obj",
         ]
@@ -560,6 +590,10 @@ class TestAsaOGsModule(TestAsaModule):
                                 network_object=dict(object=["TEST1", "TEST2"]),
                             ),
                             dict(name="bug_test_obj"),
+                            dict(
+                                name="object_only_group",
+                                network_object=dict(object=["TEST1"]),
+                            ),
                             dict(
                                 name="mixed_og_network",
                                 network_object=dict(
@@ -695,6 +729,7 @@ class TestAsaOGsModule(TestAsaModule):
             "no object-group network ANSIBLE_TEST",
             "no object-group network bug_test_obj",
             "no object-group network mixed_og_network",
+            "no object-group network object_only_group",
             "no object-group protocol test_protocol",
             "no object-group service 3300",
             "no object-group service sg-skype_ports",

--- a/tests/unit/modules/network/asa/test_asa_ogs.py
+++ b/tests/unit/modules/network/asa/test_asa_ogs.py
@@ -326,8 +326,6 @@ class TestAsaOGsModule(TestAsaModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_asa_ogs_merged_new_element_type(self):
-        """Regression test for issue #273: adding a new element type to an
-        existing group must emit the object-group context command first."""
         set_module_args(
             dict(
                 config=[


### PR DESCRIPTION
##### SUMMARY
Fix `_add_object_cmd` not emitting the `object-group` context command when adding a new element type to an existing group, causing `Invalid input detected` on the device.

Fixes #273

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cisco.asa.asa_ogs

##### ADDITIONAL INFORMATION
When a group exists with only one element type (e.g. `network-object object`) and a new element type is added (e.g. `network-object host`), `have_element` is `None` for the new type. The condition `want_element and have_element and ...` short-circuits to `False`, so `obj_cmd_added` stays `False` and the sub-command (e.g. `network-object host 1.2.3.4`) is sent without the preceding `object-group network my_group` context command.

Fix removes `have_element` from the AND guard — when `want_element` is present and `have_element` is absent/different, the context command must be emitted.