### PR TITLE
ci: disable Automation Hub publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,8 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   release:
-    uses: ansible/ansible-content-actions/.github/workflows/release.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@main
     with:
       environment: release
     secrets:
-      ah_token: ${{ secrets.AH_TOKEN }}
       ansible_galaxy_api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}


### PR DESCRIPTION
## Summary

\`cisco.asa\` is no longer published to Red Hat Automation Hub — Galaxy only going forward (confirmed with @sgarap).

Calls \`release_galaxy.yaml\` directly instead of the \`release.yaml\` wrapper, which completely bypasses the Automation Hub job.

**Why not \`ah_publish: false\`?** The \`ah_publish\` input is defined in the wrapper \`release.yaml\` but never forwarded to \`release_ah.yaml\`, so passing it has no effect — AH would still run.

## Context

The \`release.yml\` workflow was failing at the Automation Hub publish step with \`HTTP Code: 400\` because this collection no longer has a presence on Red Hat Automation Hub.