### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: "Release collection"
 on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Adds `workflow_dispatch` so the release can be triggered manually from the Actions tab, in addition to the automatic `release: published` trigger. Needed to re-run the v7.0.0 Galaxy publish after the AH fix was merged.